### PR TITLE
feat: enable support for both ODBC 17 and ODBC 18

### DIFF
--- a/.devcontainer/setup_env.sh
+++ b/.devcontainer/setup_env.sh
@@ -10,8 +10,8 @@ if [ "$(id -u)" -ne 0 ]; then
     exec sudo bash "$0" "$@"
 fi
 
-# Install Microsoft ODBC driver repo + msodbcsql17 if not already present
-if ! dpkg -s msodbcsql17 >/dev/null 2>&1; then
+# Install Microsoft ODBC driver repo + msodbcsql18 if not already present
+if ! dpkg -s msodbcsql18 >/dev/null 2>&1; then 
     echo ">>> Adding Microsoft SQL Server ODBC repository..."
     curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
     curl -sSL https://packages.microsoft.com/config/debian/11/prod.list \
@@ -21,14 +21,14 @@ if ! dpkg -s msodbcsql17 >/dev/null 2>&1; then
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
     ACCEPT_EULA=Y apt-get install -y \
-        msodbcsql17 \
+        msodbcsql18 \
         unixodbc \
         unixodbc-dev
 
     apt-get clean
     rm -rf /var/lib/apt/lists/*
 else
-    echo ">>> msodbcsql17 already installed, skipping."
+    echo ">>> msodbcsql18 already installed, skipping."
 fi
 
 # Switch back to non-root user (vscode) if needed

--- a/documents/DeploymentGuide.md
+++ b/documents/DeploymentGuide.md
@@ -82,7 +82,7 @@ If you're not using one of the above options for opening the project, then you'l
     - [Python 3.9+](https://www.python.org/downloads/)
     - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
     - [Git](https://git-scm.com/downloads)
-    - [Microsoft ODBC Driver 17](https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server?view=sql-server-ver16#version-17)
+    - [Microsoft ODBC Driver 17](https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server?view=sql-server-ver16)
 
 2. Clone the repository or download the project code via command-line:
 

--- a/src/api/ApiApp.Dockerfile
+++ b/src/api/ApiApp.Dockerfile
@@ -11,12 +11,12 @@ RUN apk add --no-cache --virtual .build-deps \
     opus-dev \
     libvpx-dev
 
-# Download and install Microsoft ODBC Driver and MSSQL tools
-RUN curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.10.6.1-1_amd64.apk \
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.10.1.1-1_amd64.apk \
-    && apk add --allow-untrusted msodbcsql17_17.10.6.1-1_amd64.apk \
-    && apk add --allow-untrusted mssql-tools_17.10.1.1-1_amd64.apk \
-    && rm msodbcsql17_17.10.6.1-1_amd64.apk mssql-tools_17.10.1.1-1_amd64.apk
+# Download and install Microsoft ODBC Driver 18 and MSSQL tools (latest release)
+RUN curl -O https://download.microsoft.com/download/fae28b9a-d880-42fd-9b98-d779f0fdd77f/msodbcsql18_18.5.1.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/7/6/d/76de322a-d860-4894-9945-f0cc5d6a45f8/mssql-tools18_18.4.1.1-1_amd64.apk \
+    && apk add --allow-untrusted msodbcsql18_18.5.1.1-1_amd64.apk \
+    && apk add --allow-untrusted mssql-tools18_18.4.1.1-1_amd64.apk \
+    && rm msodbcsql18_18.5.1.1-1_amd64.apk mssql-tools18_18.4.1.1-1_amd64.apk
 
 # Set the working directory inside the container
 WORKDIR /app
@@ -25,7 +25,7 @@ WORKDIR /app
 COPY ./requirements.txt .
 
 # Install Python dependencies
-RUN pip install --upgrade pip setuptools wheel \ 
+RUN pip install --upgrade pip setuptools wheel \
     && pip install --no-cache-dir -r requirements.txt && rm -rf /root/.cache
 
 # Copy the backend application code into the container

--- a/src/api/history_sql.py
+++ b/src/api/history_sql.py
@@ -81,29 +81,46 @@ async def get_fabric_db_connection():
     app_env = os.getenv("APP_ENV", "prod").lower()
     database = os.getenv("FABRIC_SQL_DATABASE")
     server = os.getenv("FABRIC_SQL_SERVER")
-    driver = "{ODBC Driver 17 for SQL Server}"
-    # api_uid = os.getenv("API_UID", "")
-    fabric_sql_connection_string = os.getenv("FABRIC_SQL_CONNECTION_STRING", "")
+    driver17 = "ODBC Driver 17 for SQL Server"
+    driver18 = "ODBC Driver 18 for SQL Server"
+    api_uid = os.getenv("API_UID", "")
+    fabric_sql_connection_string18 = os.getenv("FABRIC_SQL_CONNECTION_STRING", "")
+    fabric_sql_connection_string17 = f"DRIVER={driver17};SERVER={server};DATABASE={database};UID={api_uid};Authentication=ActiveDirectoryMSI"
+    
 
-    try:
+    try:       
         conn = None
-        connection_string = ""
-        if app_env == 'dev':
-            async with AzureCliCredential() as credential:
-                token = await credential.get_token("https://database.windows.net/.default")
-                token_bytes = token.token.encode("utf-16-LE")
-                token_struct = struct.pack(
-                    f"<I{len(token_bytes)}s",
-                    len(token_bytes),
-                    token_bytes
-                )
-                SQL_COPT_SS_ACCESS_TOKEN = 1256
-                connection_string = f"DRIVER={driver};SERVER={server};DATABASE={database};"
-                conn = pyodbc.connect(connection_string, attrs_before={SQL_COPT_SS_ACCESS_TOKEN: token_struct})
-        else:
-            # connection_string = f"DRIVER={driver};SERVER={server};DATABASE={database};UID={api_uid};Authentication=ActiveDirectoryMSI;"
-            connection_string = fabric_sql_connection_string
-            conn = pyodbc.connect(connection_string)
+        try:            
+            if app_env == 'dev':
+                async with AzureCliCredential() as credential:
+                    token = await credential.get_token("https://database.windows.net/.default")
+                    token_bytes = token.token.encode("utf-16-LE")
+                    token_struct = struct.pack(
+                        f"<I{len(token_bytes)}s",
+                        len(token_bytes),
+                        token_bytes
+                    )
+                    SQL_COPT_SS_ACCESS_TOKEN = 1256
+                    connection_string = f"DRIVER={driver18};SERVER={server};DATABASE={database};"
+                    conn = pyodbc.connect(connection_string, attrs_before={SQL_COPT_SS_ACCESS_TOKEN: token_struct})
+            else:
+                # connection_string = f"DRIVER={driver};SERVER={server};DATABASE={database};UID={api_uid};Authentication=ActiveDirectoryMSI;"
+                conn = pyodbc.connect(fabric_sql_connection_string18)
+        except Exception as e:
+            if app_env == 'dev':
+                async with AzureCliCredential() as credential:
+                    token = await credential.get_token("https://database.windows.net/.default")
+                    token_bytes = token.token.encode("utf-16-LE")
+                    token_struct = struct.pack(
+                        f"<I{len(token_bytes)}s",
+                        len(token_bytes),
+                        token_bytes
+                    )
+                    SQL_COPT_SS_ACCESS_TOKEN = 1256
+                    connection_string = f"DRIVER={driver17};SERVER={server};DATABASE={database};"
+                    conn = pyodbc.connect(connection_string, attrs_before={SQL_COPT_SS_ACCESS_TOKEN: token_struct})
+            else:
+                conn = pyodbc.connect(fabric_sql_connection_string17)
 
         return conn
     except pyodbc.Error as e:


### PR DESCRIPTION
This pull request updates the project to use Microsoft ODBC Driver 18 for SQL Server instead of version 17, and refactors related code and configuration to support both drivers for improved compatibility and security. The changes affect environment setup scripts, Dockerfiles, Python connection logic, and documentation.

**Environment and Dependency Updates**
* Updated `.devcontainer/setup_env.sh` to install `msodbcsql18` instead of `msodbcsql17`, ensuring the development environment uses the latest ODBC driver. 
* Updated `src/api/ApiApp.Dockerfile` to download and install Microsoft ODBC Driver 18 and corresponding MSSQL tools, replacing previous references to version 17.

**Connection Logic Refactoring**
* Refactored Python database connection logic in `src/api/history_sql.py` and `docs/notebooks/fabric-data-agents-main.ipynb` to support both ODBC Driver 17 and 18. The code now prefers Driver 18 and falls back to Driver 17 if needed, with connection string construction updated accordingly. 

**Configuration and Documentation**
* Added `API_UID` to `docs/notebooks/.env.sample` for improved authentication configuration.
* Minor update to the ODBC driver documentation link in `documents/DeploymentGuide.md` to remove the explicit version reference, reflecting support for multiple driver versions.