### PR TITLE
fix: Add onCreateCommand to set executable permissions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,6 +23,7 @@
             ]
         }
     },
+    "onCreateCommand": "chmod +x ./.devcontainer/setup_env.sh",
     "postStartCommand": "bash ./.devcontainer/setup_env.sh",
     "remoteUser": "vscode",
     "hostRequirements": {


### PR DESCRIPTION
This pull request makes a minor update to the devcontainer setup process by ensuring the environment setup script has executable permissions.

* The `onCreateCommand` in `.devcontainer/devcontainer.json` now runs `chmod +x ./.devcontainer/setup_env.sh` to guarantee the setup script is executable when the development container is created.