### PR TITLE
chore: Remove onCreateCommand from devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,6 @@
             ]
         }
     },
-    "onCreateCommand": "chmod +x ./.devcontainer/setup_env.sh",
     "postStartCommand": "bash ./.devcontainer/setup_env.sh",
     "remoteUser": "vscode",
     "hostRequirements": {


### PR DESCRIPTION
This pull request makes a small adjustment to the dev container configuration by removing the `onCreateCommand` that previously set execute permissions on the `setup_env.sh` script. The script will now only be run after the container starts.