### PR TITLE
fix: chat history will be saved for failed questions

### DIFF
--- a/src/App/src/components/Chat/Chat.tsx
+++ b/src/App/src/components/Chat/Chat.tsx
@@ -91,7 +91,7 @@ const Chat: React.FC<ChatProps> = ({
     if (!convId || !newMessages.length) {
       return;
     }
-    const isNewConversation = reqType !== 'graph' ? !selectedConversationId : false;
+    const isNewConversation = !selectedConversationId;
 
     if (false) {  // Disabled: chart display default
       setIsChartLoading(true);
@@ -508,12 +508,15 @@ const Chat: React.FC<ChatProps> = ({
           } catch {
             // Error parsing chart response
           }
-        } else if (!isChartResponseReceived) {
+        }
+        
+        // If no messages have been added yet but we have streamed content, save it
+        if (updatedMessages.length === 0 && streamMessage.content) {
           updatedMessages = [newMessage, streamMessage];
         }
       }
       
-      if (updatedMessages.length > 0 && updatedMessages[updatedMessages.length - 1]?.role !== ERROR) {
+      if (updatedMessages.length > 0) {
         saveToDB(updatedMessages, conversationId, isChatReq);
       }
     } catch (e) {

--- a/src/api/dotnet/Controllers/HistoryFabController.cs
+++ b/src/api/dotnet/Controllers/HistoryFabController.cs
@@ -79,7 +79,7 @@ public class HistoryFabController : ControllerBase
                 {
                     var nextMessage = validMessages[j];
                     
-                    if (nextMessage.Role == "assistant")
+                    if (nextMessage.Role == "assistant" || nextMessage.Role == "error")
                     {
                         pairedAssistant = nextMessage;
                         break;

--- a/src/api/python/history.py
+++ b/src/api/python/history.py
@@ -445,7 +445,7 @@ async def update_conversation(user_id: str, request_json: dict):
     # Format the incoming message object in the "chat/completions" messages format
     # then write it to the conversation history in cosmos
     messages = request_json["messages"]
-    if len(messages) > 0 and messages[-1]["role"] == "assistant":
+    if len(messages) > 0 and messages[-1]["role"] in ("assistant", "error"):
         if len(messages) > 1 and messages[-2].get("role", None) == "tool":
             # write the tool message first
             await cosmos_conversation_client.create_message(

--- a/src/api/python/history_sql.py
+++ b/src/api/python/history_sql.py
@@ -753,7 +753,7 @@ async def update_conversation(user_id: str, request_json: dict):
             )
 
         messages = request_json["messages"]
-        if len(messages) > 0 and messages[-1]["role"] == "assistant":
+        if len(messages) > 0 and messages[-1]["role"] in ("assistant", "error"):
             if len(messages) > 1 and messages[-2].get("role", None) == "tool":
                 # write the tool message first
                 await create_message(


### PR DESCRIPTION
## Purpose

This pull request introduces improvements to how messages with the `error` role are handled throughout the chat application, ensuring that error messages are correctly paired, stored, and displayed in conversation history. Additionally, it refines the logic for detecting new conversations and saving streamed messages.

**Error message handling and conversation history:**

* Updated the backend in both `history.py` and `history_sql.py` to treat messages with the `error` role the same as `assistant` messages when writing conversation history, ensuring errors are properly stored and paired with preceding tool messages. [[1]](diffhunk://#diff-d0dfaca3c60009430f17f5240a3584a4d1c8791883b86025826374c88965f1c3L448-R448) [[2]](diffhunk://#diff-0c33f8cb2c07e82a7ba21a63caf06a0a606af83abbe386d4f9cd69a6dd236c8aL756-R756)
* Modified the `HistoryFabController.cs` to pair `error` messages with user messages in addition to `assistant` messages, improving accuracy in history retrieval.

**Frontend chat logic improvements:**

* Simplified the logic in `Chat.tsx` to always consider the absence of a selected conversation as a new conversation, regardless of request type.
* Improved message saving in `Chat.tsx` by ensuring that streamed content is saved even if no messages have yet been added, and removed an unnecessary check for the `ERROR` role before saving messages.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

