### PR TITLE
fix: Refactor devcontainer setup: remove ODBC installation script and update features

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,11 +8,9 @@
         "ghcr.io/azure/azure-dev/azd:latest": {},
         "ghcr.io/devcontainers/features/azure-cli:1": {},
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-        "ghcr.io/devcontainers/features/common-utils:2": {
-            "installZsh": false,
-            "installOhMyZsh": false,
-            "installAptPackages": "unixodbc unixodbc-dev bash"
-        }
+        "ghcr.io/jlaundry/devcontainer-features/mssql-odbc-driver:1": {
+			"version": "18"
+		}
     },
     "customizations": {
         "vscode": {

--- a/.devcontainer/setup_env.sh
+++ b/.devcontainer/setup_env.sh
@@ -2,40 +2,6 @@
 
 set -euo pipefail
 
-echo ">>> Running setup_env.sh ..."
-
-# Ensure we are root for package installs
-if [ "$(id -u)" -ne 0 ]; then
-    echo "Re-running as root..."
-    exec sudo bash "$0" "$@"
-fi
-
-# Install Microsoft ODBC driver repo + msodbcsql18 if not already present
-if ! dpkg -s msodbcsql18 >/dev/null 2>&1; then 
-    echo ">>> Adding Microsoft SQL Server ODBC repository..."
-    curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-    curl -sSL https://packages.microsoft.com/config/debian/11/prod.list \
-        > /etc/apt/sources.list.d/mssql-release.list
-
-    echo ">>> Installing ODBC dependencies..."
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get update
-    ACCEPT_EULA=Y apt-get install -y \
-        msodbcsql18 \
-        unixodbc \
-        unixodbc-dev
-
-    apt-get clean
-    rm -rf /var/lib/apt/lists/*
-else
-    echo ">>> msodbcsql18 already installed, skipping."
-fi
-
-# Switch back to non-root user (vscode) if needed
-if [ "$SUDO_USER" != "" ] && [ "$SUDO_USER" != "root" ]; then
-    exec sudo -u "$SUDO_USER" bash -c "$0 remainder"
-fi
-
 git fetch
 git pull
 


### PR DESCRIPTION
## Purpose
This pull request updates the development container setup to simplify and centralize the installation of the Microsoft ODBC driver for SQL Server. The main changes are the removal of manual ODBC driver installation steps from the setup script and the adoption of a dedicated devcontainer feature for the driver.

Devcontainer configuration improvements:

* Replaced the manual installation of ODBC drivers and utilities (`common-utils` feature with custom packages) with the `mssql-odbc-driver` devcontainer feature, specifying version 18 in `.devcontainer/devcontainer.json`.

Setup script cleanup:

* Removed all logic from `setup_env.sh` related to checking for, installing, and configuring the Microsoft ODBC driver and its dependencies, as this is now handled by the devcontainer feature.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.