### PR TITLE
chore: update resource tags to include 'Type' as 'Non-WAF'

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -148,6 +148,7 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = if (!isWorksh
         TemplateName: 'Unified Data Analysis Agents'
         CreatedBy: createdBy
         DeploymentName: deployment().name
+        Type: 'Non-WAF'
       }
     )
   }

--- a/infra/main.json
+++ b/infra/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.40.2.10011",
-      "templateHash": "3285835134047245579"
+      "version": "0.41.2.15936",
+      "templateHash": "6691303275635952389"
     }
   },
   "parameters": {
@@ -446,7 +446,7 @@
       "apiVersion": "2021-04-01",
       "name": "default",
       "properties": {
-        "tags": "[union(variables('existingTags'), createObject('TemplateName', 'Unified Data Analysis Agents', 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name))]"
+        "tags": "[union(variables('existingTags'), createObject('TemplateName', 'Unified Data Analysis Agents', 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name, 'Type', 'Non-WAF'))]"
       }
     },
     {
@@ -476,8 +476,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.40.2.10011",
-              "templateHash": "14624816695106884169"
+              "version": "0.41.2.15936",
+              "templateHash": "1470310019203878344"
             }
           },
           "parameters": {
@@ -612,8 +612,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.40.2.10011",
-              "templateHash": "13563476904636358611"
+              "version": "0.41.2.15936",
+              "templateHash": "13227055421268709117"
             }
           },
           "parameters": {
@@ -1486,8 +1486,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.40.2.10011",
-                      "templateHash": "528711892506266108"
+                      "version": "0.41.2.15936",
+                      "templateHash": "13898832109536112093"
                     }
                   },
                   "parameters": {
@@ -1582,8 +1582,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.40.2.10011",
-                      "templateHash": "13137941105799442789"
+                      "version": "0.41.2.15936",
+                      "templateHash": "18427181645107655909"
                     }
                   },
                   "parameters": {
@@ -1699,8 +1699,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.40.2.10011",
-                      "templateHash": "4498626398675136258"
+                      "version": "0.41.2.15936",
+                      "templateHash": "10813437881160355473"
                     }
                   },
                   "parameters": {
@@ -1910,8 +1910,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.40.2.10011",
-                      "templateHash": "4498626398675136258"
+                      "version": "0.41.2.15936",
+                      "templateHash": "10813437881160355473"
                     }
                   },
                   "parameters": {
@@ -2182,8 +2182,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.40.2.10011",
-              "templateHash": "412766210027048493"
+              "version": "0.41.2.15936",
+              "templateHash": "15474702145744770006"
             }
           },
           "parameters": {
@@ -2337,8 +2337,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.40.2.10011",
-              "templateHash": "809927867189731780"
+              "version": "0.41.2.15936",
+              "templateHash": "18288811968777407735"
             }
           },
           "parameters": {
@@ -2471,8 +2471,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.40.2.10011",
-              "templateHash": "10632658654205885994"
+              "version": "0.41.2.15936",
+              "templateHash": "5602258252096958397"
             },
             "description": "Creates an Azure App Service plan."
           },
@@ -2625,8 +2625,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.40.2.10011",
-              "templateHash": "16473759505609016916"
+              "version": "0.41.2.15936",
+              "templateHash": "6257353120538811739"
             }
           },
           "parameters": {
@@ -2728,8 +2728,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.40.2.10011",
-                      "templateHash": "9541266673902595012"
+                      "version": "0.41.2.15936",
+                      "templateHash": "10896413449214873411"
                     }
                   },
                   "parameters": {
@@ -2850,8 +2850,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.40.2.10011",
-                              "templateHash": "17745866502369896847"
+                              "version": "0.41.2.15936",
+                              "templateHash": "9058595105823719818"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -2923,8 +2923,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.40.2.10011",
-                      "templateHash": "528711892506266108"
+                      "version": "0.41.2.15936",
+                      "templateHash": "13898832109536112093"
                     }
                   },
                   "parameters": {
@@ -3028,8 +3028,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.40.2.10011",
-                      "templateHash": "4498626398675136258"
+                      "version": "0.41.2.15936",
+                      "templateHash": "10813437881160355473"
                     }
                   },
                   "parameters": {
@@ -3311,8 +3311,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.40.2.10011",
-              "templateHash": "17382104728184779303"
+              "version": "0.41.2.15936",
+              "templateHash": "7029985584881894057"
             }
           },
           "parameters": {
@@ -3396,8 +3396,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.40.2.10011",
-                      "templateHash": "9541266673902595012"
+                      "version": "0.41.2.15936",
+                      "templateHash": "10896413449214873411"
                     }
                   },
                   "parameters": {
@@ -3518,8 +3518,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.40.2.10011",
-                              "templateHash": "17745866502369896847"
+                              "version": "0.41.2.15936",
+                              "templateHash": "9058595105823719818"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -3591,8 +3591,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.40.2.10011",
-                      "templateHash": "528711892506266108"
+                      "version": "0.41.2.15936",
+                      "templateHash": "13898832109536112093"
                     }
                   },
                   "parameters": {
@@ -3696,8 +3696,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.40.2.10011",
-                      "templateHash": "4498626398675136258"
+                      "version": "0.41.2.15936",
+                      "templateHash": "10813437881160355473"
                     }
                   },
                   "parameters": {
@@ -3941,8 +3941,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.40.2.10011",
-              "templateHash": "17740687810867727200"
+              "version": "0.41.2.15936",
+              "templateHash": "15088411755106421523"
             }
           },
           "parameters": {
@@ -4008,8 +4008,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.40.2.10011",
-                      "templateHash": "9541266673902595012"
+                      "version": "0.41.2.15936",
+                      "templateHash": "10896413449214873411"
                     }
                   },
                   "parameters": {
@@ -4130,8 +4130,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.40.2.10011",
-                              "templateHash": "17745866502369896847"
+                              "version": "0.41.2.15936",
+                              "templateHash": "9058595105823719818"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },


### PR DESCRIPTION
## Purpose
This pull request updates the infrastructure templates to add a new tag and upgrade the Bicep compiler version. The main functional change is the addition of a `Type: 'Non-WAF'` tag to the resource group tags, while the rest of the changes are related to updating the generated JSON templates to use a newer Bicep version.

**Tagging Update:**

- Added a new tag `Type: 'Non-WAF'` to the resource group tags in both the Bicep (`main.bicep`) and generated ARM template (`main.json`). This helps categorize resources and may be useful for filtering or automation. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R151) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L449-R449)

**Template Generation/Tooling:**

- Upgraded the Bicep compiler version used to generate `main.json` from `0.40.2.10011` to `0.41.2.15936`, resulting in new `templateHash` values throughout the ARM template. No functional impact, but keeps the infrastructure code up-to-date with the latest tooling. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L7-R8) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L479-R480) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L615-R616) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1489-R1490) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1585-R1586) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1702-R1703) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1913-R1914) [[8]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2185-R2186) [[9]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2340-R2341) [[10]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2474-R2475) [[11]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2628-R2629) [[12]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2731-R2732) [[13]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2853-R2854) [[14]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2926-R2927) [[15]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3031-R3032) [[16]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3314-R3315) [[17]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3399-R3400) [[18]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3521-R3522) [[19]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3594-R3595) [[20]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3699-R3700) [[21]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3944-R3945) [[22]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4011-R4012) [[23]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4133-R4134)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
