### PR TITLE
fix: improve error handling and resource management in chat and history

### DIFF
--- a/src/api/python/chat.py
+++ b/src/api/python/chat.py
@@ -147,7 +147,7 @@ async def stream_openai_text(conversation_id: str, query: str) -> StreamingRespo
     complete_response = ""
     credential = None
     chat_client = None
-    
+
     try:
         if not query:
             query = "Please provide a query."

--- a/src/api/python/chat.py
+++ b/src/api/python/chat.py
@@ -105,8 +105,11 @@ class ExpCache(TTLCache):
                     credential=credential
                 ) as project_client:
                     openai_client = project_client.get_openai_client()
-                    await openai_client.conversations.delete(conversation_id=thread_conversation_id)
-                    logger.info("Thread deleted successfully: %s", thread_conversation_id)
+                    try:
+                        await openai_client.conversations.delete(conversation_id=thread_conversation_id)
+                        logger.info("Thread deleted successfully: %s", thread_conversation_id)
+                    finally:
+                        await openai_client.close()
         except Exception as e:
             logger.error("Failed to delete thread %s: %s", thread_conversation_id, e)
         finally:
@@ -143,7 +146,8 @@ async def stream_openai_text(conversation_id: str, query: str) -> StreamingRespo
     thread = None
     complete_response = ""
     credential = None
-
+    chat_client = None
+    
     try:
         if not query:
             query = "Please provide a query."
@@ -170,30 +174,38 @@ async def stream_openai_text(conversation_id: str, query: str) -> StreamingRespo
                 model_deployment_name=os.getenv("AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME"),
             )
 
-            async with ChatAgent(
-                chat_client=chat_client,
-                tools=my_tools,
-                default_options={"tool_choice": "auto", "store": False},
-            ) as chat_agent:
+            try:
+                async with ChatAgent(
+                    chat_client=chat_client,
+                    tools=my_tools,
+                    default_options={"tool_choice": "auto", "store": True},
+                ) as chat_agent:
 
-                if thread_conversation_id:
-                    thread = chat_agent.get_new_thread(service_thread_id=thread_conversation_id)
+                    if thread_conversation_id:
+                        thread = chat_agent.get_new_thread(service_thread_id=thread_conversation_id)
 
-                if not thread_conversation_id or thread is None:
-                    openai_client = project_client.get_openai_client()
-                    conversation = await openai_client.conversations.create()
-                    thread_conversation_id = conversation.id
-                    thread = chat_agent.get_new_thread(service_thread_id=thread_conversation_id)
+                    if not thread_conversation_id or thread is None:
+                        openai_client = project_client.get_openai_client()
+                        conversation = await openai_client.conversations.create()
+                        thread_conversation_id = conversation.id
+                        thread = chat_agent.get_new_thread(service_thread_id=thread_conversation_id)
 
-                async for chunk in chat_agent.run_stream(messages=query, thread=thread):
-                    if chunk is not None and chunk.text != "":
-                        complete_response += chunk.text
-                        yield chunk.text
+                    async for chunk in chat_agent.run_stream(messages=query, thread=thread):
+                        if chunk is not None and chunk.text != "":
+                            complete_response += chunk.text
+                            yield chunk.text
 
-                # Cache the service thread ID after streaming completes
-                if thread and thread.service_thread_id:
-                    cache[conversation_id] = thread.service_thread_id
-
+                    # Cache the service thread ID after streaming completes
+                    if thread and thread.service_thread_id:
+                        cache[conversation_id] = thread.service_thread_id
+            finally:
+                # Close the AsyncOpenAI client created by AzureAIClient.initialize_client()
+                # AzureAIClient.close() does NOT close this - it only handles project_client
+                if chat_client is not None and getattr(chat_client, 'client', None) is not None:
+                    try:
+                        await chat_client.client.close()
+                    except Exception as e:
+                        logger.warning("Chat agent - Failed to close openai client: %s", e)
     except ServiceResponseException as e:
         complete_response = str(e)
         if "Rate limit is exceeded" in str(e):
@@ -397,6 +409,7 @@ async def stream_chat_request(conversation_id, query):
                     }
                     yield json.dumps(response, ensure_ascii=False) + "\n\n"
 
+            logger.info("Chat API response max 200 chars: %s, conversation_id: %s", assistant_content[:200], conversation_id)
         except ServiceResponseException as e:
             error_message = str(e)
             retry_after = "sometime"

--- a/src/api/python/history_sql.py
+++ b/src/api/python/history_sql.py
@@ -300,7 +300,7 @@ class SqlQueryTool(BaseModel):
                         row_dict[col_name] = value
                 result.append(row_dict)
             logger.info("Chat Agent - Result of SQL query: %s", result)
-            return json.dumps(result, default=str) if result else "No results found."
+            return json.dumps(result, default=str) if result and len(result) > 0 else "No results found."
         except Exception as e:
             logger.error("Chat Agent - Error executing SQL query: %s", e)
             return f"SQL query failed with error: {str(e)}. Please fix the query and try again."
@@ -578,25 +578,28 @@ async def generate_title(conversation_messages):
             logger.warning("Azure AI Agent endpoint not configured, using fallback title generation")
             return generate_fallback_title(conversation_messages)
 
-        async with AIProjectClient(
-            endpoint=AZURE_AI_AGENT_ENDPOINT,
-            credential=await get_azure_credential_async()
-        ) as project_client:
-            chat_client = AzureAIClient(
-                project_client=project_client,
-                agent_name=AGENT_NAME_TITLE,
-                use_latest_version=True,
-                model_deployment_name=AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME,
-            )
+        credential = await get_azure_credential_async()
+        try:
+            async with AIProjectClient(
+                endpoint=AZURE_AI_AGENT_ENDPOINT,
+                credential=credential
+            ) as project_client:
+                chat_client = AzureAIClient(
+                    project_client=project_client,
+                    agent_name=AGENT_NAME_TITLE,
+                    use_latest_version=True,
+                    model_deployment_name=AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME,
+                )
 
-            async with ChatAgent(
-                chat_client=chat_client,
-                tool_choice="none",
-            ) as chat_agent:
-                thread = chat_agent.get_new_thread()
-                result = await chat_agent.run(messages=final_prompt, thread=thread)
-                return str(result).strip() if result is not None else generate_fallback_title(conversation_messages)
-
+                async with ChatAgent(
+                    chat_client=chat_client,
+                    tool_choice="none",
+                ) as chat_agent:
+                    thread = chat_agent.get_new_thread()
+                    result = await chat_agent.run(messages=final_prompt, thread=thread)
+                    return str(result).strip() if result is not None else generate_fallback_title(conversation_messages)
+        finally:
+            await credential.close()
     except ServiceResponseException as sre:
         logger.warning("ServiceResponseException generating title with Azure AI Foundry agent: %s", sre)
         return generate_fallback_title(conversation_messages)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request focuses on improving resource management and error handling in the chat and history SQL modules, ensuring that client connections and credentials are properly closed, and making minor logic corrections. The most important changes are grouped below:

**Resource Management and Cleanup:**

* Ensured that the `openai_client` is always closed after deleting a thread, even if an exception occurs, by adding a `finally` block in `_delete_thread_async` (`src/api/python/chat.py`).
* Added logic to close the `chat_client.client` after streaming OpenAI text responses, handling exceptions and logging warnings if closure fails (`src/api/python/chat.py`).
* In `generate_title`, now explicitly closes the Azure credential after use by adding a `finally` block (`src/api/python/history_sql.py`).

**Logic and Behavior Improvements:**

* Updated the SQL query result logic to only return results if the list is non-empty, otherwise returns "No results found." (`src/api/python/history_sql.py`).
* Changed the default option for the chat agent to store conversations by default (`store: True`) instead of not storing (`store: False`) in `stream_openai_text` (`src/api/python/chat.py`).

**Logging Enhancements:**

* Added a log statement to output the first 200 characters of the assistant's response for debugging purposes in the chat API (`src/api/python/chat.py`).

**Minor Code Quality Improvements:**

* Refactored credential acquisition in `generate_title` to assign the credential to a variable for proper cleanup (`src/api/python/history_sql.py`).
* Initialized `chat_client` to `None` at the start of `stream_openai_text` for safer cleanup (`src/api/python/chat.py`).

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

