### PR TITLE
fix: Enhance parameter validation and documentation in agent and fabric scripts

### DIFF
--- a/.github/workflows/broken-links-checker.yml
+++ b/.github/workflows/broken-links-checker.yml
@@ -37,7 +37,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2.7.0
         with:
           args: >
-            --verbose --exclude-mail --no-progress --exclude ^https?://
+            --verbose --include-mail --no-progress --exclude ^https?://
             ${{ steps.changed-markdown-files.outputs.all_changed_files }}
           failIfEmpty: false
         env:
@@ -50,7 +50,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2.7.0
         with:
           args: >
-            --verbose --exclude-mail --no-progress --exclude ^https?://
+            --verbose --include-mail --no-progress --exclude ^https?://
             '**/*.md'
           failIfEmpty: false
         env:

--- a/documents/DeploymentGuide.md
+++ b/documents/DeploymentGuide.md
@@ -279,8 +279,21 @@ Once you've opened the project in [Codespaces](#github-codespaces), [Dev Contain
     ```
     If you don't have azd env then you need to pass parameters along with the command. Then the command will look like the following:
     ```Shell
-    bash ./infra/scripts/agent_scripts/run_create_agents_scripts.sh <project-endpoint> <solution-name> <gpt-model-name> <ai-foundry-resource-id> <api-app-name> <resource-group>
+    bash ./infra/scripts/agent_scripts/run_create_agents_scripts.sh <ai-project-endpoint> <solution-name> <gpt-model-name> <ai-foundry-resource-id> <api-app-name> <resource-group> <usecase> [<is-workshop>]
     ```
+
+    **Step 10 Parameter Reference:**
+
+    | Parameter | azd env Variable | Format / Example |
+    |---|---|---|
+    | `<ai-project-endpoint>` | `AZURE_AI_PROJECT_ENDPOINT` | URL starting with `https://` (e.g., `https://<ai-service>.services.ai.azure.com/api/projects/<project>`) |
+    | `<solution-name>` | `SOLUTION_NAME` | Alphanumeric string (e.g., `da5fi6dninkrjn`) |
+    | `<gpt-model-name>` | `AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME` | Model name (e.g., `gpt-4o-mini`, `gpt-4o`, `gpt-4`) |
+    | `<ai-foundry-resource-id>` | `AI_FOUNDRY_RESOURCE_ID` | Full resource ID starting with `/subscriptions/...` |
+    | `<api-app-name>` | `API_APP_NAME` | App Service name (e.g., `api-cs-<solutionname>`) |
+    | `<resource-group>` | `AZURE_RESOURCE_GROUP` | Resource group name (e.g., `rg-<envname>`) |
+    | `<usecase>` | `USE_CASE` | `Retail-sales-analysis` or `Insurance-improve-customer-meetings` (case-insensitive) |
+    | `<is-workshop>` | `IS_WORKSHOP` | `true` or `false` (defaults to `false`) |
 
 11. Run the bash script from the output of the azd deployment. Replace the <fabric-workspaceId> with your Fabric workspace Id created in the previous steps. The script will look like the following:
     ```Shell
@@ -289,8 +302,21 @@ Once you've opened the project in [Codespaces](#github-codespaces), [Dev Contain
 
     If you don't have azd env then you need to pass parameters along with the command. Then the command will look like the following:
     ```Shell
-    bash ./infra/scripts/fabric_scripts/run_fabric_items_scripts.sh <fabric-workspaceId> <solutionname> <ai-foundry-name> <backend-api-mid-principal> <backend-api-mid-client> <api-app-name> <resourcegroup>
+    bash ./infra/scripts/fabric_scripts/run_fabric_items_scripts.sh <fabric-workspaceId> <solutionname> <ai-foundry-name> <backend-api-mid-principal> <backend-api-mid-client> <api-app-name> <resourcegroup> <usecase>
     ```
+
+    **Step 11 Parameter Reference:**
+
+    | Parameter | azd env Variable | Format / Example |
+    |---|---|---|
+    | `<fabric-workspaceId>` | *(user-provided)* | GUID (e.g., `5bxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx246`) |
+    | `<solutionname>` | `SOLUTION_NAME` | Alphanumeric string (e.g., `da5fi6dninkrjn`) |
+    | `<ai-foundry-name>` | `AI_SERVICE_NAME` | AI Foundry account name (e.g., `aisa-<solutionname>`) |
+    | `<backend-api-mid-principal>` | `API_PID` | Managed identity Principal (Object) ID — GUID |
+    | `<backend-api-mid-client>` | `API_UID` | Managed identity Client ID — GUID |
+    | `<api-app-name>` | `API_APP_NAME` | App Service name (e.g., `api-cs-<solutionname>`) |
+    | `<resourcegroup>` | `RESOURCE_GROUP_NAME` | Resource group name (e.g., `rg-<envname>`) |
+    | `<usecase>` | `USE_CASE` | `Retail-sales-analysis` or `Insurance-improve-customer-meetings` (case-insensitive) |
 
 12. Once the script has run successfully, go to the deployed resource group, find the App Service, and get the app URL from `Default domain`.
 

--- a/infra/scripts/agent_scripts/run_create_agents_scripts.sh
+++ b/infra/scripts/agent_scripts/run_create_agents_scripts.sh
@@ -1,6 +1,26 @@
 #!/bin/bash
 set -e
 echo "Started the agent creation script setup..."
+echo ""
+
+# ─── Parameter source reference ───
+# Parameters can be provided via:
+#   1. Command-line arguments (positional, see usage below)
+#   2. azd environment variables (auto-resolved if CLI args are not provided)
+#
+# Usage:
+#   bash $0 <projectEndpoint> <solutionName> <gptModelName> <aiFoundryResourceId> <apiAppName> <resourceGroup> <usecase> [<isWorkshop>]
+#
+# Parameter details:
+#   $1  projectEndpoint          - Azure AI Project endpoint URL (e.g., https://<ai-service>.services.ai.azure.com/api/projects/<project-name>)  | azd env: AZURE_AI_AGENT_ENDPOINT
+#   $2  solutionName             - Solution name used as a suffix for resource naming                                                             | azd env: SOLUTION_NAME
+#   $3  gptModelName             - GPT model deployment name (e.g., gpt-4o-mini)                                                                 | azd env: AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME
+#   $4  aiFoundryResourceId      - Full Azure resource ID of the AI Foundry (starts with /subscriptions/...)                                     | azd env: AI_FOUNDRY_RESOURCE_ID
+#   $5  apiAppName               - Name of the backend API App Service                                                                           | azd env: API_APP_NAME
+#   $6  resourceGroup            - Azure resource group name                                                                                     | azd env: AZURE_RESOURCE_GROUP
+#   $7  usecase                  - Use case identifier: 'Retail-sales-analysis' or 'Insurance-improve-customer-meetings' (case-insensitive)      | azd env: USE_CASE
+#   $8  isWorkshopDeployment     - [Optional] Workshop mode flag: 'true' or 'false' (defaults to 'false')                                       | azd env: IS_WORKSHOP
+# ───────────────────────────────
 
 # Variables
 projectEndpoint="$1"
@@ -55,11 +75,109 @@ if [ -z "$azureAiSearchIndex" ]; then
     azureAiSearchIndex=$(azd env get-value AZURE_AI_SEARCH_INDEX 2>/dev/null || echo "")
 fi
 
-# Check if all required arguments are provided
-if [ -z "$projectEndpoint" ] || [ -z "$solutionName" ] || [ -z "$gptModelName" ] || [ -z "$aiFoundryResourceId" ] || [ -z "$apiAppName" ] || [ -z "$resourceGroup" ] || [ -z "$usecase" ]; then
-    echo "Usage: $0 <projectEndpoint> <solutionName> <gptModelName> <aiFoundryResourceId> <apiAppName> <resourceGroup> <usecase>"
+# ─── Validate required parameters ───
+echo "Validating parameters..."
+validation_failed=false
+
+if [ -z "$projectEndpoint" ]; then
+    echo "❌ ERROR: 'projectEndpoint' is missing."
+    echo "   Expected: Azure AI Project endpoint URL (e.g., https://<ai-service>.services.ai.azure.com/api/projects/<project-name>)"
+    echo "   Source:   Pass as argument \$1 or set azd env variable AZURE_AI_AGENT_ENDPOINT"
+    validation_failed=true
+elif [[ ! "$projectEndpoint" =~ ^https:// ]]; then
+    echo "❌ ERROR: 'projectEndpoint' has invalid format: $projectEndpoint"
+    echo "   Expected: URL starting with https:// (e.g., https://<ai-service>.services.ai.azure.com/api/projects/<project-name>)"
+    validation_failed=true
+fi
+
+if [ -z "$solutionName" ]; then
+    echo "❌ ERROR: 'solutionName' is missing."
+    echo "   Expected: Solution name suffix used for resource naming (e.g., da5fi6dninkrjn)"
+    echo "   Source:   Pass as argument \$2 or set azd env variable SOLUTION_NAME"
+    validation_failed=true
+fi
+
+if [ -z "$gptModelName" ]; then
+    echo "❌ ERROR: 'gptModelName' is missing."
+    echo "   Expected: GPT model deployment name (e.g., gpt-4o-mini, gpt-4o, gpt-4)"
+    echo "   Source:   Pass as argument \$3 or set azd env variable AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME"
+    validation_failed=true
+fi
+
+if [ -z "$aiFoundryResourceId" ]; then
+    echo "❌ ERROR: 'aiFoundryResourceId' is missing."
+    echo "   Expected: Full Azure resource ID (e.g., /subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<name>)"
+    echo "   Source:   Pass as argument \$4 or set azd env variable AI_FOUNDRY_RESOURCE_ID"
+    validation_failed=true
+elif [[ ! "$aiFoundryResourceId" =~ ^/subscriptions/ ]]; then
+    echo "❌ ERROR: 'aiFoundryResourceId' has invalid format: $aiFoundryResourceId"
+    echo "   Expected: Must start with /subscriptions/ (e.g., /subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<name>)"
+    validation_failed=true
+fi
+
+if [ -z "$apiAppName" ]; then
+    echo "❌ ERROR: 'apiAppName' is missing."
+    echo "   Expected: Name of the backend API App Service (e.g., api-cs-<solutionname>)"
+    echo "   Source:   Pass as argument \$5 or set azd env variable API_APP_NAME"
+    validation_failed=true
+fi
+
+if [ -z "$resourceGroup" ]; then
+    echo "❌ ERROR: 'resourceGroup' is missing."
+    echo "   Expected: Azure resource group name (e.g., rg-<envname>)"
+    echo "   Source:   Pass as argument \$6 or set azd env variable AZURE_RESOURCE_GROUP"
+    validation_failed=true
+fi
+
+if [ -z "$usecase" ]; then
+    echo "❌ ERROR: 'usecase' is missing."
+    echo "   Expected: 'Retail-sales-analysis' or 'Insurance-improve-customer-meetings' (case-insensitive)"
+    echo "   Source:   Pass as argument \$7 or set azd env variable USE_CASE"
+    validation_failed=true
+else
+    usecase_lower=$(echo "$usecase" | tr '[:upper:]' '[:lower:]')
+    if [[ "$usecase_lower" != "retail-sales-analysis" && "$usecase_lower" != "insurance-improve-customer-meetings" ]]; then
+        echo "❌ ERROR: 'usecase' has invalid value: $usecase"
+        echo "   Expected: 'Retail-sales-analysis' or 'Insurance-improve-customer-meetings' (case-insensitive)"
+        validation_failed=true
+    fi
+fi
+
+if [ -n "$isWorkshopDeployment" ]; then
+    is_workshop_lower=$(echo "$isWorkshopDeployment" | tr '[:upper:]' '[:lower:]')
+    if [[ "$is_workshop_lower" != "true" && "$is_workshop_lower" != "false" ]]; then
+        echo "❌ ERROR: 'isWorkshopDeployment' has invalid value: $isWorkshopDeployment"
+        echo "   Expected: 'true' or 'false' (defaults to 'false' if not provided)"
+        validation_failed=true
+    fi
+fi
+
+if [ "$validation_failed" = true ]; then
+    echo ""
+    echo "──────────────────────────────────────────────────────────────────"
+    echo "❌ Parameter validation failed. Please fix the errors above."
+    echo ""
+    echo "Usage: $0 <projectEndpoint> <solutionName> <gptModelName> <aiFoundryResourceId> <apiAppName> <resourceGroup> <usecase> [<isWorkshop>]"
+    echo ""
+    echo "Parameters can be provided via command-line arguments or resolved automatically from azd environment variables."
+    echo "Run 'azd env get-values' to check your current azd environment."
+    echo "──────────────────────────────────────────────────────────────────"
     exit 1
 fi
+
+# ─── Print resolved parameters ───
+echo ""
+echo "=== Resolved Parameters ==="
+echo "  Project Endpoint:      $projectEndpoint"
+echo "  Solution Name:         $solutionName"
+echo "  GPT Model Name:        $gptModelName"
+echo "  AI Foundry Resource ID: $aiFoundryResourceId"
+echo "  API App Name:          $apiAppName"
+echo "  Resource Group:        $resourceGroup"
+echo "  Use Case:              $usecase"
+echo "  Workshop Deployment:   $isWorkshopDeployment"
+echo "==========================="
+echo ""
 
 # Check if user is logged in to Azure
 echo "Checking Azure authentication..."

--- a/infra/scripts/fabric_scripts/run_fabric_items_scripts.sh
+++ b/infra/scripts/fabric_scripts/run_fabric_items_scripts.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
 echo "Starting the fabric items script"
+echo ""
+
+# ─── Parameter source reference ───
+# Parameters can be provided via:
+#   1. Command-line arguments (positional, see usage below)
+#   2. azd environment variables (auto-resolved if CLI args are not provided)
+#
+# Usage:
+#   bash $0 <fabricWorkspaceId> <solutionName> <aiFoundryName> <backend_app_pid> <backend_app_uid> <app_service> <resource_group> <usecase>
+#
+# Parameter details:
+#   $1  fabricWorkspaceId  - Fabric workspace GUID (e.g., 5bd3db28-534a-498d-a7e7-2a1e48fb3246)                                            | user-provided
+#   $2  solutionName       - Solution name suffix used for resource naming (e.g., da5fi6dninkrjn)                                           | azd env: SOLUTION_NAME
+#   $3  aiFoundryName      - Name of the AI Foundry cognitive services account (e.g., aisa-<solutionname>)                                  | azd env: AI_SERVICE_NAME
+#   $4  backend_app_pid    - Backend app managed identity Principal (Object) ID (GUID)                                                      | azd env: API_PID
+#   $5  backend_app_uid    - Backend app managed identity Client ID (GUID)                                                                  | azd env: API_UID
+#   $6  app_service        - Name of the backend API App Service (e.g., api-cs-<solutionname>)                                              | azd env: API_APP_NAME
+#   $7  resource_group     - Azure resource group name (e.g., rg-<envname>)                                                                 | azd env: RESOURCE_GROUP_NAME
+#   $8  usecase            - Use case identifier: 'Retail-sales-analysis' or 'Insurance-improve-customer-meetings' (case-insensitive)       | azd env: USE_CASE
+# ───────────────────────────────
 
 # Variables
 fabricWorkspaceId="$1"
@@ -40,11 +60,111 @@ if [ -z "$usecase" ]; then
     usecase=$(azd env get-value USE_CASE)
 fi
 
-# Check if all required arguments are present
-if [ -z "$fabricWorkspaceId" ] || [ -z "$solutionName" ] || [ -z "$aiFoundryName" ] || [ -z "$backend_app_pid" ] || [ -z "$backend_app_uid" ] || [ -z "$app_service" ] || [ -z "$resource_group" ] || [ -z "$usecase" ]; then
+# ─── Validate required parameters ───
+echo "Validating parameters..."
+validation_failed=false
+
+if [ -z "$fabricWorkspaceId" ]; then
+    echo "❌ ERROR: 'fabricWorkspaceId' is missing."
+    echo "   Expected: Fabric workspace GUID (e.g., 5bd3db28-534a-498d-a7e7-2a1e48fb3246)"
+    echo "   Source:   Pass as argument \$1 (this parameter must always be provided manually)"
+    validation_failed=true
+elif [[ ! "$fabricWorkspaceId" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+    echo "❌ ERROR: 'fabricWorkspaceId' is not a valid GUID: $fabricWorkspaceId"
+    echo "   Expected: GUID format (e.g., 5bd3db28-534a-498d-a7e7-2a1e48fb3246)"
+    validation_failed=true
+fi
+
+if [ -z "$solutionName" ]; then
+    echo "❌ ERROR: 'solutionName' is missing."
+    echo "   Expected: Solution name suffix used for resource naming (e.g., da5fi6dninkrjn)"
+    echo "   Source:   Pass as argument \$2 or set azd env variable SOLUTION_NAME"
+    validation_failed=true
+fi
+
+if [ -z "$aiFoundryName" ]; then
+    echo "❌ ERROR: 'aiFoundryName' is missing."
+    echo "   Expected: Name of the AI Foundry cognitive services account (e.g., aisa-<solutionname>)"
+    echo "   Source:   Pass as argument \$3 or set azd env variable AI_SERVICE_NAME"
+    validation_failed=true
+fi
+
+if [ -z "$backend_app_pid" ]; then
+    echo "❌ ERROR: 'backend_app_pid' (backend app managed identity Principal ID) is missing."
+    echo "   Expected: GUID (e.g., 776846ec-52a3-4ebd-8495-217d592c4158)"
+    echo "   Source:   Pass as argument \$4 or set azd env variable API_PID"
+    validation_failed=true
+elif [[ ! "$backend_app_pid" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+    echo "❌ ERROR: 'backend_app_pid' is not a valid GUID: $backend_app_pid"
+    echo "   Expected: GUID format (e.g., 776846ec-52a3-4ebd-8495-217d592c4158)"
+    validation_failed=true
+fi
+
+if [ -z "$backend_app_uid" ]; then
+    echo "❌ ERROR: 'backend_app_uid' (backend app managed identity Client ID) is missing."
+    echo "   Expected: GUID (e.g., c37a7fd9-86d8-40bc-a18c-7011ec963e03)"
+    echo "   Source:   Pass as argument \$5 or set azd env variable API_UID"
+    validation_failed=true
+elif [[ ! "$backend_app_uid" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+    echo "❌ ERROR: 'backend_app_uid' is not a valid GUID: $backend_app_uid"
+    echo "   Expected: GUID format (e.g., c37a7fd9-86d8-40bc-a18c-7011ec963e03)"
+    validation_failed=true
+fi
+
+if [ -z "$app_service" ]; then
+    echo "❌ ERROR: 'app_service' is missing."
+    echo "   Expected: Name of the backend API App Service (e.g., api-cs-<solutionname>)"
+    echo "   Source:   Pass as argument \$6 or set azd env variable API_APP_NAME"
+    validation_failed=true
+fi
+
+if [ -z "$resource_group" ]; then
+    echo "❌ ERROR: 'resource_group' is missing."
+    echo "   Expected: Azure resource group name (e.g., rg-<envname>)"
+    echo "   Source:   Pass as argument \$7 or set azd env variable RESOURCE_GROUP_NAME"
+    validation_failed=true
+fi
+
+if [ -z "$usecase" ]; then
+    echo "❌ ERROR: 'usecase' is missing."
+    echo "   Expected: 'Retail-sales-analysis' or 'Insurance-improve-customer-meetings' (case-insensitive)"
+    echo "   Source:   Pass as argument \$8 or set azd env variable USE_CASE"
+    validation_failed=true
+else
+    usecase_lower=$(echo "$usecase" | tr '[:upper:]' '[:lower:]')
+    if [[ "$usecase_lower" != "retail-sales-analysis" && "$usecase_lower" != "insurance-improve-customer-meetings" ]]; then
+        echo "❌ ERROR: 'usecase' has invalid value: $usecase"
+        echo "   Expected: 'Retail-sales-analysis' or 'Insurance-improve-customer-meetings' (case-insensitive)"
+        validation_failed=true
+    fi
+fi
+
+if [ "$validation_failed" = true ]; then
+    echo ""
+    echo "──────────────────────────────────────────────────────────────────"
+    echo "❌ Parameter validation failed. Please fix the errors above."
+    echo ""
     echo "Usage: $0 <fabricWorkspaceId> <solutionName> <aiFoundryName> <backend_app_pid> <backend_app_uid> <app_service> <resource_group> <usecase>"
+    echo ""
+    echo "Parameters can be provided via command-line arguments or resolved automatically from azd environment variables."
+    echo "Run 'azd env get-values' to check your current azd environment."
+    echo "──────────────────────────────────────────────────────────────────"
     exit 1
 fi
+
+# ─── Print resolved parameters ───
+echo ""
+echo "=== Resolved Parameters ==="
+echo "  Fabric Workspace ID:   $fabricWorkspaceId"
+echo "  Solution Name:         $solutionName"
+echo "  AI Foundry Name:       $aiFoundryName"
+echo "  Backend App PID:       $backend_app_pid"
+echo "  Backend App UID:       $backend_app_uid"
+echo "  App Service:           $app_service"
+echo "  Resource Group:        $resource_group"
+echo "  Use Case:              $usecase"
+echo "==========================="
+echo ""
 
 # Check if user is logged in to Azure
 echo "Checking Azure authentication..."


### PR DESCRIPTION
## Purpose
This pull request improves the deployment documentation and scripts by adding detailed parameter references, usage instructions, and robust input validation for deployment scripts. These enhancements help users understand how to provide required parameters, clarify the expected formats and sources, and ensure errors are caught early with clear messages.

**Documentation improvements:**

* Added comprehensive parameter reference tables to `documents/DeploymentGuide.md` for both agent and fabric deployment steps, specifying the mapping between CLI arguments and environment variables, expected formats, and examples.

**Script usability and validation:**

* Updated `infra/scripts/agent_scripts/run_create_agents_scripts.sh` and `infra/scripts/fabric_scripts/run_fabric_items_scripts.sh` to include usage instructions and parameter source references at the top of each script, making it easier for users to understand how to run them and what inputs are required. [[1]](diffhunk://#diff-bfb65ac3d115f97bd3545f894d6f3e002c9b2b72071df87a08ae4af8d8cbe517R4-R23) [[2]](diffhunk://#diff-99209a4d125678f1546b9d6c8cfbb93d74792b208067b924fbb451d893883d26R3-R22)
* Introduced detailed parameter validation logic in both scripts, checking for missing or incorrectly formatted arguments (such as URLs, GUIDs, and allowed values), and providing clear error messages and usage hints if validation fails. [[1]](diffhunk://#diff-bfb65ac3d115f97bd3545f894d6f3e002c9b2b72071df87a08ae4af8d8cbe517L58-R181) [[2]](diffhunk://#diff-99209a4d125678f1546b9d6c8cfbb93d74792b208067b924fbb451d893883d26L43-R168)
* Both scripts now print a summary of resolved parameters before proceeding, helping users confirm that all values are correctly set. [[1]](diffhunk://#diff-bfb65ac3d115f97bd3545f894d6f3e002c9b2b72071df87a08ae4af8d8cbe517L58-R181) [[2]](diffhunk://#diff-99209a4d125678f1546b9d6c8cfbb93d74792b208067b924fbb451d893883d26L43-R168)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

