### PR TITLE
fix: enhance caching logic for service thread IDs

### DIFF
--- a/src/api/python/chat.py
+++ b/src/api/python/chat.py
@@ -197,7 +197,12 @@ async def stream_openai_text(conversation_id: str, query: str) -> StreamingRespo
 
                     # Cache the service thread ID after streaming completes
                     if thread and thread.service_thread_id:
-                        cache[conversation_id] = thread.service_thread_id
+                        if thread.service_thread_id.startswith("conv_"):
+                            cache[conversation_id] = thread.service_thread_id
+                        elif thread_conversation_id and thread_conversation_id.startswith("conv_"):
+                            cache[conversation_id] = thread_conversation_id
+                        else:
+                            cache[conversation_id] = thread.service_thread_id
             finally:
                 # Close the AsyncOpenAI client created by AzureAIClient.initialize_client()
                 # AzureAIClient.close() does NOT close this - it only handles project_client


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request improves the logic for caching the service thread ID after streaming completes in the `stream_openai_text` function. The update ensures that only thread IDs starting with `"conv_"` are cached, falling back to alternative IDs if necessary.

Caching logic improvements:

* Updated the caching mechanism to prioritize storing `service_thread_id` or `thread_conversation_id` only if they start with `"conv_"`, enhancing the reliability of conversation ID mapping.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

