### PR TITLE
fix: Update telemetry template check to require version 1.1 and sanitize log

### DIFF
--- a/.github/workflows/telemetry-template-check.yml
+++ b/.github/workflows/telemetry-template-check.yml
@@ -18,12 +18,12 @@ jobs:
 
       - name: Check for required metadata template line
         run: |
-          if grep -E '^\s*#\s*template:\s*agentic-applications-for-unified-data-foundation@1\.0' azure.yaml; then
+          if grep -E '^\s*#\s*template:\s*agentic-applications-for-unified-data-foundation@1\.1' azure.yaml; then
             echo "ERROR: 'template' line is commented out in azure.yaml! Please uncomment template line."
             exit 1
           fi
 
-          if ! grep -E '^\s*template:\s*agentic-applications-for-unified-data-foundation@1\.0' azure.yaml; then
+          if ! grep -E '^\s*template:\s*agentic-applications-for-unified-data-foundation@1\.1' azure.yaml; then
             echo "ERROR: Required 'template' line is missing in azure.yaml! Please add template line for telemetry."
             exit 1
           fi

--- a/src/api/dotnet/Controllers/ChatController.cs
+++ b/src/api/dotnet/Controllers/ChatController.cs
@@ -56,7 +56,10 @@ public class ChatController : ControllerBase
         
         var (convId, _) = await _sqlRepo.EnsureConversationAsync(userId ?? string.Empty, request.ConversationId, title: string.Empty, ct);
 
-        _logger.LogInformation("Chat request received - query: {Query}, conversation_id: {ConversationId}", request.Query, convId);
+        // Sanitize user input to prevent log forging attacks
+        var sanitizedQuery = request.Query.Replace(Environment.NewLine, "").Replace("\r", "").Replace("\n", "");
+        var sanitizedConvId = convId.Replace(Environment.NewLine, "").Replace("\r", "").Replace("\n", "");
+        _logger.LogInformation("Chat request received - query: {Query}, conversation_id: {ConversationId}", sanitizedQuery, sanitizedConvId);
         
         // Use Agent Framework AIAgent for RAG/AI response with function tools  
         AIAgent agent = agentService.Agent;


### PR DESCRIPTION
## Purpose
This pull request introduces two main updates: it updates the required metadata template version in the GitHub Actions workflow for telemetry, and it improves security in logging within the chat API controller by sanitizing user input to prevent log forging attacks.

**Workflow and CI/CD Updates:**

* [`.github/workflows/telemetry-template-check.yml`](diffhunk://#diff-4a309dbc21fc716da022fdb05209b134bf34b44aa5ce39f4e4125a06c5b0f51cL21-R26): Updated the workflow to check for `agentic-applications-for-unified-data-foundation@1.1` instead of `@1.0` in `azure.yaml`, ensuring the project uses the latest required template for telemetry.

**Security Improvements:**

* [`src/api/dotnet/Controllers/ChatController.cs`](diffhunk://#diff-be4935e1d30f2f170f06047facdf84bd5675634cc15123c9d542427590b6c7c1L59-R62): Sanitized the `query` and `conversation_id` fields before logging to prevent log forging attacks by removing newline and carriage return characters from user input.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

