### PR TITLE
fix: Add versioning for AI model deployments in Bicep template

### DIFF
--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -81,6 +81,7 @@ var aiModelDeployments = concat([
       name: 'GlobalStandard'
       capacity: embeddingDeploymentCapacity
     }
+    version: '1'
     raiPolicyName: 'Microsoft.Default'
   }
 ] : [])
@@ -188,6 +189,7 @@ resource aiServicesDeployments 'Microsoft.CognitiveServices/accounts/deployments
     model: {
       format: 'OpenAI'
       name: aiModeldeployment.model
+      version: !empty(aiModeldeployment.version) ? aiModeldeployment.version : null
     }
     raiPolicyName: aiModeldeployment.raiPolicyName
   }

--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -197,6 +197,9 @@ resource aiServicesDeployments 'Microsoft.CognitiveServices/accounts/deployments
     name: aiModeldeployment.sku.name
     capacity: aiModeldeployment.sku.capacity
   }
+  dependsOn: [
+    aiProject
+  ]
 }]
 
 resource aiSearch 'Microsoft.Search/searchServices@2024-06-01-preview' = if(isWorkshop) {

--- a/infra/main.json
+++ b/infra/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "15169639720885287728"
+      "version": "0.42.1.51946",
+      "templateHash": "13465571187195810362"
     }
   },
   "parameters": {
@@ -494,8 +494,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "3472930527601001530"
+              "version": "0.42.1.51946",
+              "templateHash": "10307461230259065083"
             }
           },
           "parameters": {
@@ -647,8 +647,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "2751944493515658289"
+              "version": "0.42.1.51946",
+              "templateHash": "4369483223004606662"
             }
           },
           "parameters": {
@@ -1001,7 +1001,7 @@
             "aiSearchName": "[format('{0}{1}', variables('abbrs').ai.aiSearch, parameters('solutionName'))]",
             "storageName": "[take(format('{0}{1}', variables('abbrs').storage.storageAccount, toLower(replace(parameters('solutionName'), '-', ''))), 24)]",
             "aiSearchConnectionName": "[format('search-connection-{0}', parameters('solutionName'))]",
-            "aiModelDeployments": "[concat(createArray(createObject('name', parameters('gptModelName'), 'model', parameters('gptModelName'), 'sku', createObject('name', parameters('deploymentType'), 'capacity', parameters('gptDeploymentCapacity')), 'version', parameters('gptModelVersion'), 'raiPolicyName', 'Microsoft.Default')), if(parameters('isWorkshop'), createArray(createObject('name', parameters('embeddingModel'), 'model', parameters('embeddingModel'), 'sku', createObject('name', 'GlobalStandard', 'capacity', parameters('embeddingDeploymentCapacity')), 'raiPolicyName', 'Microsoft.Default')), createArray()))]",
+            "aiModelDeployments": "[concat(createArray(createObject('name', parameters('gptModelName'), 'model', parameters('gptModelName'), 'sku', createObject('name', parameters('deploymentType'), 'capacity', parameters('gptDeploymentCapacity')), 'version', parameters('gptModelVersion'), 'raiPolicyName', 'Microsoft.Default')), if(parameters('isWorkshop'), createArray(createObject('name', parameters('embeddingModel'), 'model', parameters('embeddingModel'), 'sku', createObject('name', 'GlobalStandard', 'capacity', parameters('embeddingDeploymentCapacity')), 'version', '1', 'raiPolicyName', 'Microsoft.Default')), createArray()))]",
             "useExisting": "[not(empty(parameters('existingLogAnalyticsWorkspaceId')))]",
             "existingLawSubscription": "[if(variables('useExisting'), split(parameters('existingLogAnalyticsWorkspaceId'), '/')[2], '')]",
             "existingLawResourceGroup": "[if(variables('useExisting'), split(parameters('existingLogAnalyticsWorkspaceId'), '/')[4], '')]",
@@ -1111,7 +1111,8 @@
               "properties": {
                 "model": {
                   "format": "OpenAI",
-                  "name": "[variables('aiModelDeployments')[copyIndex()].model]"
+                  "name": "[variables('aiModelDeployments')[copyIndex()].model]",
+                  "version": "[if(not(empty(variables('aiModelDeployments')[copyIndex()].version)), variables('aiModelDeployments')[copyIndex()].version, null())]"
                 },
                 "raiPolicyName": "[variables('aiModelDeployments')[copyIndex()].raiPolicyName]"
               },
@@ -1120,6 +1121,7 @@
                 "capacity": "[variables('aiModelDeployments')[copyIndex()].sku.capacity]"
               },
               "dependsOn": [
+                "[resourceId('Microsoft.CognitiveServices/accounts/projects', variables('aiServicesName'), variables('aiProjectName'))]",
                 "[resourceId('Microsoft.CognitiveServices/accounts', variables('aiServicesName'))]"
               ]
             },
@@ -1533,8 +1535,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "16993105740966505250"
+                      "version": "0.42.1.51946",
+                      "templateHash": "176104670941550577"
                     }
                   },
                   "parameters": {
@@ -1665,8 +1667,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "17611628239034995102"
+                      "version": "0.42.1.51946",
+                      "templateHash": "15940656462374031268"
                     }
                   },
                   "parameters": {
@@ -1791,8 +1793,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "312825370778438846"
+                      "version": "0.42.1.51946",
+                      "templateHash": "4631236656784318419"
                     }
                   },
                   "parameters": {
@@ -2053,8 +2055,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "312825370778438846"
+                      "version": "0.42.1.51946",
+                      "templateHash": "4631236656784318419"
                     }
                   },
                   "parameters": {
@@ -2431,8 +2433,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "16063600162233365078"
+              "version": "0.42.1.51946",
+              "templateHash": "1345542987569517937"
             }
           },
           "parameters": {
@@ -2607,8 +2609,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "13662733255787521583"
+              "version": "0.42.1.51946",
+              "templateHash": "4284424173515148533"
             }
           },
           "parameters": {
@@ -2762,8 +2764,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "8356071713215305084"
+              "version": "0.42.1.51946",
+              "templateHash": "5180121198949389556"
             },
             "description": "Creates an Azure App Service plan."
           },
@@ -2927,8 +2929,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "13102491909160505927"
+              "version": "0.42.1.51946",
+              "templateHash": "16506430922588282048"
             }
           },
           "parameters": {
@@ -3008,7 +3010,7 @@
             "existingAIServicesName": "[if(not(empty(parameters('azureExistingAIProjectResourceId'))), split(parameters('azureExistingAIProjectResourceId'), '/')[8], '')]",
             "existingAIProjectName": "[if(not(empty(parameters('azureExistingAIProjectResourceId'))), split(parameters('azureExistingAIProjectResourceId'), '/')[10], '')]",
             "imageName": "[format('DOCKER|{0}.azurecr.io/da-api:{1}', parameters('acrName'), parameters('imageTag'))]",
-            "reactAppLayoutConfig": "{\n  \"appConfig\": {\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 70,\n        \"CHATHISTORY\": 30\n      }\n    }\n  }\n}"
+            "reactAppLayoutConfig": "{\r\n  \"appConfig\": {\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 70,\r\n        \"CHATHISTORY\": 30\r\n      }\r\n    }\r\n  }\r\n}"
           },
           "resources": [
             {
@@ -3060,8 +3062,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "5691398111935750345"
+                      "version": "0.42.1.51946",
+                      "templateHash": "13815496434466107484"
                     }
                   },
                   "parameters": {
@@ -3194,8 +3196,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.41.2.15936",
-                              "templateHash": "9058595105823719818"
+                              "version": "0.42.1.51946",
+                              "templateHash": "14059865609608429555"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -3273,8 +3275,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "16993105740966505250"
+                      "version": "0.42.1.51946",
+                      "templateHash": "176104670941550577"
                     }
                   },
                   "parameters": {
@@ -3414,8 +3416,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "312825370778438846"
+                      "version": "0.42.1.51946",
+                      "templateHash": "4631236656784318419"
                     }
                   },
                   "parameters": {
@@ -3764,8 +3766,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "13110594575107685913"
+              "version": "0.42.1.51946",
+              "templateHash": "3861058490487788669"
             }
           },
           "parameters": {
@@ -3838,7 +3840,7 @@
             "existingAIServicesName": "[if(not(empty(parameters('azureExistingAIProjectResourceId'))), split(parameters('azureExistingAIProjectResourceId'), '/')[8], '')]",
             "existingAIProjectName": "[if(not(empty(parameters('azureExistingAIProjectResourceId'))), split(parameters('azureExistingAIProjectResourceId'), '/')[10], '')]",
             "imageName": "[format('DOCKER|{0}.azurecr.io/da-api-dotnet:{1}', parameters('acrName'), parameters('imageTag'))]",
-            "reactAppLayoutConfig": "{\n  \"appConfig\": {\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 70,\n        \"CHATHISTORY\": 30\n      }\n    }\n  }\n}"
+            "reactAppLayoutConfig": "{\r\n  \"appConfig\": {\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 70,\r\n        \"CHATHISTORY\": 30\r\n      }\r\n    }\r\n  }\r\n}"
           },
           "resources": [
             {
@@ -3876,8 +3878,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "5691398111935750345"
+                      "version": "0.42.1.51946",
+                      "templateHash": "13815496434466107484"
                     }
                   },
                   "parameters": {
@@ -4010,8 +4012,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.41.2.15936",
-                              "templateHash": "9058595105823719818"
+                              "version": "0.42.1.51946",
+                              "templateHash": "14059865609608429555"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -4089,8 +4091,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "16993105740966505250"
+                      "version": "0.42.1.51946",
+                      "templateHash": "176104670941550577"
                     }
                   },
                   "parameters": {
@@ -4230,8 +4232,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "312825370778438846"
+                      "version": "0.42.1.51946",
+                      "templateHash": "4631236656784318419"
                     }
                   },
                   "parameters": {
@@ -4538,8 +4540,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "12518244873126064566"
+              "version": "0.42.1.51946",
+              "templateHash": "15310769069660875050"
             }
           },
           "parameters": {
@@ -4623,8 +4625,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "5691398111935750345"
+                      "version": "0.42.1.51946",
+                      "templateHash": "13815496434466107484"
                     }
                   },
                   "parameters": {
@@ -4757,8 +4759,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.41.2.15936",
-                              "templateHash": "9058595105823719818"
+                              "version": "0.42.1.51946",
+                              "templateHash": "14059865609608429555"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },


### PR DESCRIPTION
## Purpose
This pull request makes small but important adjustments to the AI model deployment configuration in the `infra/deploy_ai_foundry.bicep` file. The changes ensure that the model version is explicitly set and that the AI deployment depends on the AI project resource.

Deployment configuration improvements:

* Explicitly sets the `version` property to `'1'` for the AI model deployment configuration in the `aiModelDeployments` array.
* Updates the `aiServicesDeployments` resource to pass the model `version` if it exists, otherwise sets it to `null`.

Deployment dependency management:

* Adds a `dependsOn` clause to ensure `aiServicesDeployments` is deployed only after the `aiProject` resource.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.