### PR TITLE
fix: downmerge issue & copilotcomments - standardize environment variable naming across workflows and scripts

### DIFF
--- a/.github/workflows/azd-template-validation.yml
+++ b/.github/workflows/azd-template-validation.yml
@@ -36,7 +36,7 @@ jobs:
           AZURE_LOCATION: ${{ secrets.AZURE_LOCATION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AZURE_ENV_AI_DEPLOYMENTS_LOCATION: ${{ vars.AZURE_ENV_AI_DEPLOYMENTS_LOCATION }}
-          AZURE_ENV_USE_CASE: ${{ vars.AZURE_ENV_USE_CASE }}
+          USE_CASE: ${{ vars.USE_CASE }}
           DEPLOYING_USER_PRINCIPAL_TYPE: ServicePrincipal
 
       - name: Print result

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -18,7 +18,7 @@ jobs:
       AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
       AZURE_DEV_COLLECT_TELEMETRY: ${{ vars.AZURE_DEV_COLLECT_TELEMETRY }}
       AZURE_ENV_AI_DEPLOYMENTS_LOCATION: ${{ vars.AZURE_ENV_AI_DEPLOYMENTS_LOCATION }}
-      AZURE_ENV_USE_CASE: ${{ vars.AZURE_ENV_USE_CASE }}
+      USE_CASE: ${{ vars.USE_CASE }}
       DEPLOYING_USER_PRINCIPAL_TYPE: ServicePrincipal
     steps:
       - name: Checkout Code
@@ -56,5 +56,5 @@ jobs:
           azd config set defaults.subscription "$AZURE_SUBSCRIPTION_ID"
           azd env set AZURE_AI_SERVICE_LOCATION="$AZURE_LOCATION"
           azd env set AZURE_ENV_AI_DEPLOYMENTS_LOCATION="$AZURE_ENV_AI_DEPLOYMENTS_LOCATION"
-          azd env set AZURE_ENV_USE_CASE="$AZURE_ENV_USE_CASE"
+          azd env set USE_CASE="$USE_CASE"
           azd up --no-prompt

--- a/.github/workflows/deploy-orchestrator.yml
+++ b/.github/workflows/deploy-orchestrator.yml
@@ -107,7 +107,7 @@ jobs:
     with:
       TEST_URL: ${{ needs.deploy.outputs.WEB_APPURL || inputs.existing_webapp_url }}
       TEST_SUITE: ${{ inputs.trigger_type == 'workflow_dispatch' && inputs.run_e2e_tests || 'GoldenPath-Testing' }}
-      AZURE_ENV_USE_CASE: ${{ inputs.AZURE_ENV_USE_CASE }}
+      USE_CASE: ${{ inputs.USE_CASE }}
     secrets: inherit
 
   cleanup-deployment:

--- a/infra/scripts/validate_bicep_params.py
+++ b/infra/scripts/validate_bicep_params.py
@@ -36,7 +36,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 # Environment variables exempt from the AZURE_ENV_ naming convention.
-_ENV_VAR_EXCEPTIONS = {"AZURE_LOCATION", "AZURE_EXISTING_AIPROJECT_RESOURCE_ID", "IS_WORKSHOP"}
+_ENV_VAR_EXCEPTIONS = {
+    "AZURE_LOCATION",
+    "AZURE_EXISTING_AIPROJECT_RESOURCE_ID",
+    "IS_WORKSHOP",
+    "USE_CASE",
+    "BACKEND_RUNTIME_STACK",
+    "DEPLOYING_USER_PRINCIPAL_TYPE",
+}
 
 # ---------------------------------------------------------------------------
 # Bicep param parser
@@ -108,7 +115,7 @@ def parse_parameters_env_vars(json_path: Path) -> dict[str, list[str]]:
         data = json.loads(sanitized)
         params = data.get("parameters", {})
     except json.JSONDecodeError:
-        pass
+        params = {}
 
     # Walk each top-level parameter and scan its entire serialized value
     # for ${VAR} references from the original text.

--- a/src/start.cmd
+++ b/src/start.cmd
@@ -36,6 +36,10 @@ for /f "tokens=1,* delims==" %%A in ('type "%ENV_FILE%"') do (
         set AZURE_SQLDB_SERVER=%%~B
         for /f "tokens=1 delims=." %%C in ("%%~B") do set AZURE_SQLDB_SERVER_NAME=%%C
     )
+    if "%%A"=="SQLDB_SERVER" if not defined AZURE_SQLDB_SERVER (
+        set AZURE_SQLDB_SERVER=%%~B
+        for /f "tokens=1 delims=." %%C in ("%%~B") do set AZURE_SQLDB_SERVER_NAME=%%C
+    )
 )
 
 REM Copy .env to src/api


### PR DESCRIPTION
## Purpose
This pull request standardizes the naming of the `USE_CASE` environment variable across several GitHub Actions workflows and updates related scripts to recognize this change. It also improves error handling in the Bicep parameter validation script and adds support for alternative SQL DB server variable names in the startup script.

**Environment variable naming standardization:**

* Updated all workflow files (`azure-dev.yml`, `azd-template-validation.yml`, and `deploy-orchestrator.yml`) to use `USE_CASE` instead of `AZURE_ENV_USE_CASE` for consistency. [[1]](diffhunk://#diff-b0a856ddf67919f52d7a1db1bc5c4edf96e59c4761717ca93aeb11239456c2d7L21-R21) [[2]](diffhunk://#diff-b0a856ddf67919f52d7a1db1bc5c4edf96e59c4761717ca93aeb11239456c2d7L59-R59) [[3]](diffhunk://#diff-711c28063a0d1eeaded24f81685f191e9f411f063808c59f668bc8c6f47eeb13L39-R39) [[4]](diffhunk://#diff-d13e946b411762697bc3a5825b5350445fa0296d5c1b1489776f7b82a84dfca4L110-R110)
* Added `USE_CASE`, `BACKEND_RUNTIME_STACK`, and `DEPLOYING_USER_PRINCIPAL_TYPE` to the list of environment variable exceptions in `validate_bicep_params.py`, so they are exempt from the `AZURE_ENV_` naming convention check.

**Script and error handling improvements:**

* Improved error handling in `validate_bicep_params.py` by ensuring that if JSON decoding fails, `params` is set to an empty dictionary instead of being left undefined.
* Updated `src/start.cmd` to recognize `SQLDB_SERVER` as an alternative to `AZURE_SQLDB_SERVER`, improving compatibility with different environment variable names.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.