### PR TITLE
fix: Update RUN_URL references

### DIFF
--- a/.github/workflows/job-send-notification.yml
+++ b/.github/workflows/job-send-notification.yml
@@ -155,8 +155,10 @@ jobs:
           LOGICAPP_URL: ${{ secrets.EMAILNOTIFICATION_LOGICAPP_URL_TA }}
           CONFIG_LABEL: ${{ steps.config.outputs.CONFIG_LABEL }}
           CLEANUP_STATUS: ${{ steps.cleanup.outputs.CLEANUP_STATUS }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
-          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           RESOURCE_GROUP="$INPUT_RESOURCE_GROUP_NAME"
           
           EMAIL_BODY=$(cat <<EOF
@@ -234,7 +236,7 @@ jobs:
           TEST_SUITE_NAME: ${{ steps.test_suite.outputs.TEST_SUITE_NAME }}
           INPUT_TEST_REPORT_URL: ${{ inputs.TEST_REPORT_URL }}
         run: |
-          RUN_URL="https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}"
+          RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           TEST_REPORT_URL="$INPUT_TEST_REPORT_URL"
           WEBAPP_URL="${INPUT_WEB_APPURL:-$INPUT_EXISTING_WEBAPP_URL}"
           RESOURCE_GROUP="$INPUT_RESOURCE_GROUP_NAME"
@@ -265,7 +267,7 @@ jobs:
           RUN_E2E_TESTS: ${{ env.RUN_E2E_TESTS }}
           TEST_SUITE_NAME: ${{ steps.test_suite.outputs.TEST_SUITE_NAME }}
         run: |
-          RUN_URL="https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}"
+          RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           EXISTING_URL="$INPUT_EXISTING_WEBAPP_URL"
           TEST_REPORT_URL="$INPUT_TEST_REPORT_URL"
           
@@ -295,7 +297,7 @@ jobs:
           RUN_E2E_TESTS: ${{ env.RUN_E2E_TESTS }}
           TEST_SUITE_NAME: ${{ steps.test_suite.outputs.TEST_SUITE_NAME }}
         run: |
-          RUN_URL="https://github.com/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }}"
+          RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           EXISTING_URL="$INPUT_EXISTING_WEBAPP_URL"
           TEST_REPORT_URL="$INPUT_TEST_REPORT_URL"
           


### PR DESCRIPTION
## Purpose
This pull request updates the way the GitHub Actions workflow constructs the `RUN_URL` used in notification jobs. The main change is to consistently use the `GITHUB_REPOSITORY` and `GITHUB_RUN_ID` environment variables directly, rather than referencing them with `${{ env.* }}` syntax. This makes the code more consistent and less error-prone.

**Workflow consistency and environment variable usage:**

* Updated all instances in `.github/workflows/job-send-notification.yml` to use `GITHUB_REPOSITORY` and `GITHUB_RUN_ID` directly (e.g., `${GITHUB_REPOSITORY}`) when constructing the `RUN_URL`, instead of mixing with `${{ env.GITHUB_REPOSITORY }}` or `${{ github.repository }}`. [[1]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76R158-R161) [[2]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76L237-R239) [[3]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76L268-R270) [[4]](diffhunk://#diff-f63b15a32fa412295c3d660104505c6a2345b066844d2ba99d182458e9f5cc76L298-R300)
* Ensured that `GITHUB_REPOSITORY` and `GITHUB_RUN_ID` are explicitly set as environment variables in the workflow steps where needed.

These changes improve the readability and reliability of the workflow by standardizing how environment variables are accessed.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

