### PR TITLE
feat: add code coverage PR comments for Python and .NET workflows

### DIFF
--- a/.github/workflows/unit-tests-dotnet.yml
+++ b/.github/workflows/unit-tests-dotnet.yml
@@ -151,6 +151,18 @@ jobs:
             fi
           fi
 
+      - name: Coverage Comment
+        if: |
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == false &&
+          steps.find-coverage.outputs.coverage_file != ''
+        uses: MishaKav/pytest-coverage-comment@26f986d2599c288bb62f623d29c2da98609e9cd4  # v1.6.0
+        with:
+          pytest-xml-coverage-path: ${{ steps.find-coverage.outputs.coverage_file }}
+          title: .NET Coverage Report
+          report-only-changed-files: true
+
       - name: Fail if tests failed
         if: steps.dotnet-test.outcome != 'success'
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -133,6 +133,17 @@ jobs:
           echo "::error::Unit tests failed or coverage below ${{ env.COVERAGE_THRESHOLD }}% threshold"
           exit 1
 
+      - name: Pytest Coverage Comment
+        if: |
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == false
+        uses: MishaKav/pytest-coverage-comment@26f986d2599c288bb62f623d29c2da98609e9cd4  # v1.6.0
+        with:
+          pytest-xml-coverage-path: coverage.xml
+          junitxml-path: test-results.xml
+          report-only-changed-files: true
+
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()


### PR DESCRIPTION
## Summary
This PR adds automated code coverage comments to pull requests for both Python and .NET unit test workflows.

## Changes
- **unit-tests.yml** (Python): Added MishaKav/pytest-coverage-comment step to post coverage summary and per-file coverage for changed files
- **unit-tests-dotnet.yml** (.NET): Added MishaKav/pytest-coverage-comment step to post coverage from Cobertura XML reports

## Details
- Uses \\MishaKav/pytest-coverage-comment@v1.6.0\\ pinned by SHA (\\26f986d2599c288bb62f623d29c2da98609e9cd4\\) for security (Microsoft standard)
- \\eport-only-changed-files: true\\ shows per-file coverage only for files modified in the PR
- Fork PR safety: skips comment step for fork PRs (read-only tokens)
- \\lways()\\ condition ensures comments are posted even when tests fail