### PR TITLE
fix: align main_custom.bicep env var names with standardized naming

### DIFF
--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -243,10 +243,10 @@ module backend_custom 'deploy_backend_custom.bicep' = if (shouldDeployApp && bac
     enableCosmosDb: shouldDeployApp && isWorkshop
     logAnalyticsWorkspaceId: resolvedLogAnalyticsWorkspaceId
     appSettings: {
-      AZURE_OPENAI_DEPLOYMENT_MODEL: gptModelName
-      AZURE_OPENAI_EMBEDDING_MODEL: embeddingModel
+      AZURE_ENV_GPT_MODEL_NAME: gptModelName
+      AZURE_ENV_EMBEDDING_DEPLOYMENT_NAME: embeddingModel
       AZURE_OPENAI_ENDPOINT: aifoundry.outputs.aiServicesTarget
-      AZURE_OPENAI_API_VERSION: azureOpenAIApiVersion
+      AZURE_ENV_OPENAI_API_VERSION: azureOpenAIApiVersion
       AZURE_OPENAI_RESOURCE: aifoundry.outputs.aiServicesName
       AZURE_AI_AGENT_ENDPOINT: aifoundry.outputs.projectEndpoint
       AZURE_AI_AGENT_API_VERSION: azureAiAgentApiVersion
@@ -256,9 +256,9 @@ module backend_custom 'deploy_backend_custom.bicep' = if (shouldDeployApp && bac
       AZURE_COSMOSDB_CONVERSATIONS_CONTAINER: isWorkshop ? cosmosDBModule!.outputs.cosmosContainerName : ''
       AZURE_COSMOSDB_DATABASE: isWorkshop ? cosmosDBModule!.outputs.cosmosDatabaseName : ''
       AZURE_COSMOSDB_ENABLE_FEEDBACK: isWorkshop ? 'True' : ''
-      SQLDB_DATABASE: (isWorkshop && azureEnvOnly) ? sqlDBModule!.outputs.sqlDbName : ''
-      SQLDB_SERVER: (isWorkshop && azureEnvOnly) ? sqlDBModule!.outputs.sqlServerName : ''
-      SQLDB_USER_MID: (isWorkshop && azureEnvOnly) ? managedIdentityModule.outputs.managedIdentityBackendAppOutput.clientId : ''
+      AZURE_SQLDB_DATABASE: (isWorkshop && azureEnvOnly) ? sqlDBModule!.outputs.sqlDbName : ''
+      AZURE_SQLDB_SERVER: (isWorkshop && azureEnvOnly) ? sqlDBModule!.outputs.sqlServerName : ''
+      AZURE_SQLDB_USER_MID: (isWorkshop && azureEnvOnly) ? managedIdentityModule.outputs.managedIdentityBackendAppOutput.clientId : ''
       API_UID: managedIdentityModule.outputs.managedIdentityBackendAppOutput.clientId
       AZURE_AI_SEARCH_ENDPOINT: isWorkshop ? aifoundry.outputs.aiSearchTarget : ''
       AZURE_AI_SEARCH_INDEX: isWorkshop ? 'knowledge_index' : ''
@@ -299,10 +299,10 @@ module backend_csapi_docker 'deploy_backend_csapi_docker.bicep' = if (shouldDepl
     aiServicesName: aifoundry.outputs.aiServicesName
     azureExistingAIProjectResourceId: azureExistingAIProjectResourceId
     appSettings: {
-      AZURE_OPENAI_DEPLOYMENT_MODEL: gptModelName
-      AZURE_OPENAI_EMBEDDING_MODEL: embeddingModel
+      AZURE_ENV_GPT_MODEL_NAME: gptModelName
+      AZURE_ENV_EMBEDDING_DEPLOYMENT_NAME: embeddingModel
       AZURE_OPENAI_ENDPOINT: aifoundry.outputs.aiServicesTarget
-      AZURE_OPENAI_API_VERSION: azureOpenAIApiVersion
+      AZURE_ENV_OPENAI_API_VERSION: azureOpenAIApiVersion
       AZURE_OPENAI_RESOURCE: aifoundry.outputs.aiServicesName
       AZURE_AI_AGENT_ENDPOINT: aifoundry.outputs.projectEndpoint
       AZURE_AI_AGENT_API_VERSION: azureAiAgentApiVersion
@@ -372,22 +372,22 @@ output AZURE_COSMOSDB_CONVERSATIONS_CONTAINER string = isWorkshop ? 'conversatio
 output AZURE_COSMOSDB_DATABASE string = isWorkshop ? 'db_conversation_history' : ''
 
 @description('GPT model deployment name (e.g., gpt-4o-mini)')
-output AZURE_OPENAI_DEPLOYMENT_MODEL string = gptModelName
+output AZURE_ENV_GPT_MODEL_NAME string = gptModelName
 
 @description('Azure OpenAI service endpoint URL')
 output AZURE_OPENAI_ENDPOINT string = aifoundry.outputs.aiServicesTarget
 
 @description('Embedding model deployment name for vector search')
-output AZURE_OPENAI_EMBEDDING_MODEL string = embeddingModel
+output AZURE_ENV_EMBEDDING_DEPLOYMENT_NAME string = embeddingModel
 
 @description('Azure SQL database name (Azure-only mode)')
-output SQLDB_DATABASE string = (isWorkshop && azureEnvOnly) ? sqlDBModule!.outputs.sqlDbName : ''
+output AZURE_SQLDB_DATABASE string = (isWorkshop && azureEnvOnly) ? sqlDBModule!.outputs.sqlDbName : ''
 
 @description('Azure SQL server fully qualified domain name (Azure-only mode)')
-output SQLDB_SERVER string = (isWorkshop && azureEnvOnly) ? sqlDBModule!.outputs.sqlServerName : ''
+output AZURE_SQLDB_SERVER string = (isWorkshop && azureEnvOnly) ? sqlDBModule!.outputs.sqlServerName : ''
 
 @description('Managed identity client ID for SQL authentication (Azure-only mode)')
-output SQLDB_USER_MID string = (isWorkshop && azureEnvOnly) ? managedIdentityModule.outputs.managedIdentityBackendAppOutput.clientId : ''
+output AZURE_SQLDB_USER_MID string = (isWorkshop && azureEnvOnly) ? managedIdentityModule.outputs.managedIdentityBackendAppOutput.clientId : ''
 
 @description('Backend API managed identity client ID')
 output API_UID string = managedIdentityModule.outputs.managedIdentityBackendAppOutput.clientId


### PR DESCRIPTION
This pull request updates environment variable and output names in the `infra/main_custom.bicep` file to use a more consistent naming convention, primarily by prefixing them with `AZURE_ENV_` or `AZURE_SQLDB_`. This change improves clarity and standardization across the deployment configuration.

**Environment variable and output renaming for clarity and consistency:**

* Renamed OpenAI-related app settings from `AZURE_OPENAI_DEPLOYMENT_MODEL`, `AZURE_OPENAI_EMBEDDING_MODEL`, and `AZURE_OPENAI_API_VERSION` to `AZURE_ENV_GPT_MODEL_NAME`, `AZURE_ENV_EMBEDDING_DEPLOYMENT_NAME`, and `AZURE_ENV_OPENAI_API_VERSION` in both backend deployment modules (`backend_custom` and `backend_csapi_docker`). [[1]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L246-R249) [[2]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L302-R305)
* Renamed SQL database-related app settings from `SQLDB_DATABASE`, `SQLDB_SERVER`, and `SQLDB_USER_MID` to `AZURE_SQLDB_DATABASE`, `AZURE_SQLDB_SERVER`, and `AZURE_SQLDB_USER_MID`.
* Updated corresponding output variable names for OpenAI and SQL database settings to match the new naming convention (e.g., `AZURE_OPENAI_DEPLOYMENT_MODEL` → `AZURE_ENV_GPT_MODEL_NAME`, `SQLDB_DATABASE` → `AZURE_SQLDB_DATABASE`).Rename legacy env var names in app settings and outputs to match main.bicep conventions:
- AZURE_OPENAI_DEPLOYMENT_MODEL -> AZURE_ENV_GPT_MODEL_NAME
- AZURE_OPENAI_EMBEDDING_MODEL -> AZURE_ENV_EMBEDDING_DEPLOYMENT_NAME
- AZURE_OPENAI_API_VERSION -> AZURE_ENV_OPENAI_API_VERSION
- SQLDB_DATABASE -> AZURE_SQLDB_DATABASE
- SQLDB_SERVER -> AZURE_SQLDB_SERVER
- SQLDB_USER_MID -> AZURE_SQLDB_USER_MID

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

