### PR TITLE
fix: Update AI Foundry project principal ID reference

### DIFF
--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -609,4 +609,4 @@ output applicationInsightsConnectionString string = applicationInsights.properti
 output aiFoundryResourceId string = !empty(azureExistingAIProjectResourceId) ? azureExistingAIProjectResourceId : aiServices.id
 
 @description('The principal ID of the AI Foundry project managed identity.')
-output aiProjectPrincipalId string = !empty(existingAIProjectName) ? existingOpenAiProject.outputs.aiProjectPrincipalId : aiProject.identity.principalId
+output aiProjectPrincipalId string = !empty(existingAIProjectName) ? assignFoundryRoleToMIExisting.outputs.aiProjectPrincipalId : aiProject.identity.principalId

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "11151180340377947802"
+      "templateHash": "2129642045338742014"
     }
   },
   "parameters": {
@@ -148,7 +148,7 @@
     },
     "imageTag": {
       "type": "string",
-      "defaultValue": "[if(parameters('isWorkshop'), 'latest_workshop', 'latest_v2')]"
+      "defaultValue": "latest_v2"
     },
     "deployApp": {
       "type": "bool",
@@ -208,7 +208,7 @@
     },
     "acrName": {
       "type": "string",
-      "defaultValue": "[if(parameters('isWorkshop'), 'dataagentscontainerregworkshop', 'dataagentscontainerreg')]",
+      "defaultValue": "dataagentscontainerreg",
       "metadata": {
         "description": "Name of the Azure Container Registry"
       }
@@ -656,7 +656,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "4369483223004606662"
+              "templateHash": "10182101882903139683"
             }
           },
           "parameters": {
@@ -2407,7 +2407,7 @@
               "metadata": {
                 "description": "The principal ID of the AI Foundry project managed identity."
               },
-              "value": "[if(not(empty(variables('existingAIProjectName'))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('existingAIServiceSubscription'), variables('existingAIServiceResourceGroup')), 'Microsoft.Resources/deployments', 'assignOpenAIRoleToAISearchExisting'), '2025-04-01').outputs.aiProjectPrincipalId.value, reference(resourceId('Microsoft.CognitiveServices/accounts/projects', variables('aiServicesName'), variables('aiProjectName')), '2025-04-01-preview', 'full').identity.principalId)]"
+              "value": "[if(not(empty(variables('existingAIProjectName'))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('existingAIServiceSubscription'), variables('existingAIServiceResourceGroup')), 'Microsoft.Resources/deployments', 'assignFoundryRoleToMI'), '2025-04-01').outputs.aiProjectPrincipalId.value, reference(resourceId('Microsoft.CognitiveServices/accounts/projects', variables('aiServicesName'), variables('aiProjectName')), '2025-04-01-preview', 'full').identity.principalId)]"
             }
           }
         }
@@ -2442,7 +2442,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "1345542987569517937"
+              "templateHash": "9983501054937831856"
             }
           },
           "parameters": {
@@ -2496,8 +2496,8 @@
                 "count": "[length(variables('containers'))]"
               },
               "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
-              "apiVersion": "2022-05-15",
-              "name": "[format('{0}/{1}/{2}', split(format('{0}/{1}', parameters('accountName'), variables('databaseName')), '/')[0], split(format('{0}/{1}', parameters('accountName'), variables('databaseName')), '/')[1], variables('containers')[copyIndex()].name)]",
+              "apiVersion": "2024-11-15",
+              "name": "[format('{0}/{1}/{2}', parameters('accountName'), variables('databaseName'), variables('containers')[copyIndex()].name)]",
               "properties": {
                 "resource": {
                   "id": "[variables('containers')[copyIndex()].id]",
@@ -2510,12 +2510,12 @@
                 "options": {}
               },
               "dependsOn": [
-                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', split(format('{0}/{1}', parameters('accountName'), variables('databaseName')), '/')[0], split(format('{0}/{1}', parameters('accountName'), variables('databaseName')), '/')[1])]"
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('accountName'), variables('databaseName'))]"
               ]
             },
             {
               "type": "Microsoft.DocumentDB/databaseAccounts",
-              "apiVersion": "2022-08-15",
+              "apiVersion": "2024-11-15",
               "name": "[parameters('accountName')]",
               "kind": "[parameters('kind')]",
               "location": "[parameters('solutionLocation')]",
@@ -2545,7 +2545,7 @@
             },
             {
               "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
-              "apiVersion": "2022-05-15",
+              "apiVersion": "2024-11-15",
               "name": "[format('{0}/{1}', parameters('accountName'), variables('databaseName'))]",
               "properties": {
                 "resource": {


### PR DESCRIPTION
## Purpose
This pull request updates the infrastructure deployment templates to improve consistency, update resource API versions, and adjust output references for managed identities. The most significant changes are related to how the principal ID for the AI Foundry project is determined, updates to default parameter values, and modernization of Cosmos DB resource definitions.

**Managed Identity Output and Role Assignment:**
- Changed the logic for the `aiProjectPrincipalId` output in both `infra/deploy_ai_foundry.bicep` and `infra/main.json` to reference the output from the `assignFoundryRoleToMIExisting` or `assignFoundryRoleToMI` deployment instead of the previous OpenAI-specific deployment. This ensures the principal ID is correctly set based on the new role assignment resource. [[1]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L612-R612) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2410-R2410)

**Parameter Defaults and Registry Naming:**
- Updated the default value for the `imageTag` parameter to always use `"latest_v2"`, removing the conditional logic for workshop deployments.
- Set the default value for the `acrName` parameter to `"dataagentscontainerreg"`, removing the workshop-specific registry name.

**Cosmos DB Resource Modernization:**
- Upgraded the `apiVersion` for Cosmos DB resources (`Microsoft.DocumentDB/databaseAccounts`, `sqlDatabases`, and `containers`) from `2022-05-15` and `2022-08-15` to `2024-11-15` for better compatibility and new features. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2499-R2500) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2513-R2518) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2548-R2548)
- Simplified the resource naming and dependency expressions for Cosmos DB containers and databases to use direct parameter references instead of string manipulation and splitting. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2499-R2500) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2513-R2518)

**Template Metadata:**
- Updated template hash values in the `_generator` metadata to reflect the latest changes and ensure template versioning accuracy. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R8) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L659-R659) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2445-R2445)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
