### PR TITLE
chore: downmerge from main to dev

### DIFF
--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -609,4 +609,4 @@ output applicationInsightsConnectionString string = applicationInsights.properti
 output aiFoundryResourceId string = !empty(azureExistingAIProjectResourceId) ? azureExistingAIProjectResourceId : aiServices.id
 
 @description('The principal ID of the AI Foundry project managed identity.')
-output aiProjectPrincipalId string = !empty(existingAIProjectName) ? existingOpenAiProject.outputs.aiProjectPrincipalId : aiProject.identity.principalId
+output aiProjectPrincipalId string = !empty(existingAIProjectName) ? assignFoundryRoleToMIExisting.outputs.aiProjectPrincipalId : aiProject.identity.principalId

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "11151180340377947802"
+      "templateHash": "2129642045338742014"
     }
   },
   "parameters": {
@@ -148,7 +148,7 @@
     },
     "imageTag": {
       "type": "string",
-      "defaultValue": "[if(parameters('isWorkshop'), 'latest_workshop', 'latest_v2')]"
+      "defaultValue": "latest_v2"
     },
     "deployApp": {
       "type": "bool",
@@ -208,7 +208,7 @@
     },
     "acrName": {
       "type": "string",
-      "defaultValue": "[if(parameters('isWorkshop'), 'dataagentscontainerregworkshop', 'dataagentscontainerreg')]",
+      "defaultValue": "dataagentscontainerreg",
       "metadata": {
         "description": "Name of the Azure Container Registry"
       }
@@ -656,7 +656,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "4369483223004606662"
+              "templateHash": "10182101882903139683"
             }
           },
           "parameters": {
@@ -2407,7 +2407,7 @@
               "metadata": {
                 "description": "The principal ID of the AI Foundry project managed identity."
               },
-              "value": "[if(not(empty(variables('existingAIProjectName'))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('existingAIServiceSubscription'), variables('existingAIServiceResourceGroup')), 'Microsoft.Resources/deployments', 'assignOpenAIRoleToAISearchExisting'), '2025-04-01').outputs.aiProjectPrincipalId.value, reference(resourceId('Microsoft.CognitiveServices/accounts/projects', variables('aiServicesName'), variables('aiProjectName')), '2025-04-01-preview', 'full').identity.principalId)]"
+              "value": "[if(not(empty(variables('existingAIProjectName'))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('existingAIServiceSubscription'), variables('existingAIServiceResourceGroup')), 'Microsoft.Resources/deployments', 'assignFoundryRoleToMI'), '2025-04-01').outputs.aiProjectPrincipalId.value, reference(resourceId('Microsoft.CognitiveServices/accounts/projects', variables('aiServicesName'), variables('aiProjectName')), '2025-04-01-preview', 'full').identity.principalId)]"
             }
           }
         }
@@ -2442,7 +2442,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "1345542987569517937"
+              "templateHash": "9983501054937831856"
             }
           },
           "parameters": {
@@ -2496,8 +2496,8 @@
                 "count": "[length(variables('containers'))]"
               },
               "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
-              "apiVersion": "2022-05-15",
-              "name": "[format('{0}/{1}/{2}', split(format('{0}/{1}', parameters('accountName'), variables('databaseName')), '/')[0], split(format('{0}/{1}', parameters('accountName'), variables('databaseName')), '/')[1], variables('containers')[copyIndex()].name)]",
+              "apiVersion": "2024-11-15",
+              "name": "[format('{0}/{1}/{2}', parameters('accountName'), variables('databaseName'), variables('containers')[copyIndex()].name)]",
               "properties": {
                 "resource": {
                   "id": "[variables('containers')[copyIndex()].id]",
@@ -2510,12 +2510,12 @@
                 "options": {}
               },
               "dependsOn": [
-                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', split(format('{0}/{1}', parameters('accountName'), variables('databaseName')), '/')[0], split(format('{0}/{1}', parameters('accountName'), variables('databaseName')), '/')[1])]"
+                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('accountName'), variables('databaseName'))]"
               ]
             },
             {
               "type": "Microsoft.DocumentDB/databaseAccounts",
-              "apiVersion": "2022-08-15",
+              "apiVersion": "2024-11-15",
               "name": "[parameters('accountName')]",
               "kind": "[parameters('kind')]",
               "location": "[parameters('solutionLocation')]",
@@ -2545,7 +2545,7 @@
             },
             {
               "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
-              "apiVersion": "2022-05-15",
+              "apiVersion": "2024-11-15",
               "name": "[format('{0}/{1}', parameters('accountName'), variables('databaseName'))]",
               "properties": {
                 "resource": {

--- a/infra/main.json
+++ b/infra/main.json
@@ -4,10 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.41.2.15936",
-      "templateHash": "9672645937662746895"
       "version": "0.42.1.51946",
-      "templateHash": "2129642045338742014"
+      "templateHash": "9599971480895993310"
     }
   },
   "parameters": {
@@ -151,7 +149,6 @@
     "imageTag": {
       "type": "string",
       "defaultValue": "latest_v2"
-      "defaultValue": "latest_v2"
     },
     "deployApp": {
       "type": "bool",
@@ -211,7 +208,6 @@
     },
     "acrName": {
       "type": "string",
-      "defaultValue": "dataagentscontainerreg",
       "defaultValue": "dataagentscontainerreg",
       "metadata": {
         "description": "Name of the Azure Container Registry"
@@ -506,8 +502,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "16520346065233412795"
+              "version": "0.42.1.51946",
+              "templateHash": "16599617067634025517"
             }
           },
           "parameters": {
@@ -659,10 +655,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "8591463010800502990"
               "version": "0.42.1.51946",
-              "templateHash": "10182101882903139683"
+              "templateHash": "16848402676405380264"
             }
           },
           "parameters": {
@@ -1549,8 +1543,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "7102384623735058513"
+                      "version": "0.42.1.51946",
+                      "templateHash": "9737384618167428949"
                     }
                   },
                   "parameters": {
@@ -1681,8 +1675,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "11081397954697037272"
+                      "version": "0.42.1.51946",
+                      "templateHash": "563276668960385803"
                     }
                   },
                   "parameters": {
@@ -1807,8 +1801,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "18204160206538111033"
+                      "version": "0.42.1.51946",
+                      "templateHash": "5534842626934673245"
                     }
                   },
                   "parameters": {
@@ -2069,8 +2063,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "18204160206538111033"
+                      "version": "0.42.1.51946",
+                      "templateHash": "5534842626934673245"
                     }
                   },
                   "parameters": {
@@ -2413,8 +2407,7 @@
               "metadata": {
                 "description": "The principal ID of the AI Foundry project managed identity."
               },
-              "value": "[if(not(empty(variables('existingAIProjectName'))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('existingAIServiceSubscription'), variables('existingAIServiceResourceGroup')), 'Microsoft.Resources/deployments', 'assignOpenAIRoleToAISearchExisting'), '2025-04-01').outputs.aiProjectPrincipalId.value, reference(resourceId('Microsoft.CognitiveServices/accounts/projects', variables('aiServicesName'), variables('aiProjectName')), '2025-12-01', 'full').identity.principalId)]"
-              "value": "[if(not(empty(variables('existingAIProjectName'))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('existingAIServiceSubscription'), variables('existingAIServiceResourceGroup')), 'Microsoft.Resources/deployments', 'assignFoundryRoleToMI'), '2025-04-01').outputs.aiProjectPrincipalId.value, reference(resourceId('Microsoft.CognitiveServices/accounts/projects', variables('aiServicesName'), variables('aiProjectName')), '2025-04-01-preview', 'full').identity.principalId)]"
+              "value": "[if(not(empty(variables('existingAIProjectName'))), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('existingAIServiceSubscription'), variables('existingAIServiceResourceGroup')), 'Microsoft.Resources/deployments', 'assignFoundryRoleToMI'), '2025-04-01').outputs.aiProjectPrincipalId.value, reference(resourceId('Microsoft.CognitiveServices/accounts/projects', variables('aiServicesName'), variables('aiProjectName')), '2025-12-01', 'full').identity.principalId)]"
             }
           }
         }
@@ -2448,10 +2441,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "9967851409498533467"
               "version": "0.42.1.51946",
-              "templateHash": "9983501054937831856"
+              "templateHash": "5276047402530342059"
             }
           },
           "parameters": {
@@ -2507,8 +2498,6 @@
               "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers",
               "apiVersion": "2025-10-15",
               "name": "[format('{0}/{1}/{2}', parameters('accountName'), variables('databaseName'), variables('containers')[copyIndex()].name)]",
-              "apiVersion": "2024-11-15",
-              "name": "[format('{0}/{1}/{2}', parameters('accountName'), variables('databaseName'), variables('containers')[copyIndex()].name)]",
               "properties": {
                 "resource": {
                   "id": "[variables('containers')[copyIndex()].id]",
@@ -2522,13 +2511,11 @@
               },
               "dependsOn": [
                 "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('accountName'), variables('databaseName'))]"
-                "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlDatabases', parameters('accountName'), variables('databaseName'))]"
               ]
             },
             {
               "type": "Microsoft.DocumentDB/databaseAccounts",
               "apiVersion": "2025-10-15",
-              "apiVersion": "2024-11-15",
               "name": "[parameters('accountName')]",
               "kind": "[parameters('kind')]",
               "location": "[parameters('solutionLocation')]",
@@ -2559,7 +2546,6 @@
             {
               "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
               "apiVersion": "2025-10-15",
-              "apiVersion": "2024-11-15",
               "name": "[format('{0}/{1}', parameters('accountName'), variables('databaseName'))]",
               "properties": {
                 "resource": {
@@ -2631,8 +2617,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "17654889923112799825"
+              "version": "0.42.1.51946",
+              "templateHash": "13789806692563246245"
             }
           },
           "parameters": {
@@ -2786,8 +2772,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "12034179423713313166"
+              "version": "0.42.1.51946",
+              "templateHash": "14100113989210974449"
             },
             "description": "Creates an Azure App Service plan."
           },
@@ -2951,8 +2937,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "302150059202714840"
+              "version": "0.42.1.51946",
+              "templateHash": "7475108240263648131"
             }
           },
           "parameters": {
@@ -3084,8 +3070,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "17548571893651101785"
+                      "version": "0.42.1.51946",
+                      "templateHash": "3327197611512448778"
                     }
                   },
                   "parameters": {
@@ -3218,8 +3204,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.41.2.15936",
-                              "templateHash": "6091329104405289493"
+                              "version": "0.42.1.51946",
+                              "templateHash": "11771554881309131596"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -3297,8 +3283,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "7102384623735058513"
+                      "version": "0.42.1.51946",
+                      "templateHash": "9737384618167428949"
                     }
                   },
                   "parameters": {
@@ -3438,8 +3424,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "18204160206538111033"
+                      "version": "0.42.1.51946",
+                      "templateHash": "5534842626934673245"
                     }
                   },
                   "parameters": {
@@ -3788,8 +3774,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "7075310952479810537"
+              "version": "0.42.1.51946",
+              "templateHash": "15675271098519791556"
             }
           },
           "parameters": {
@@ -3900,8 +3886,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "17548571893651101785"
+                      "version": "0.42.1.51946",
+                      "templateHash": "3327197611512448778"
                     }
                   },
                   "parameters": {
@@ -4034,8 +4020,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.41.2.15936",
-                              "templateHash": "6091329104405289493"
+                              "version": "0.42.1.51946",
+                              "templateHash": "11771554881309131596"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -4113,8 +4099,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "7102384623735058513"
+                      "version": "0.42.1.51946",
+                      "templateHash": "9737384618167428949"
                     }
                   },
                   "parameters": {
@@ -4254,8 +4240,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "18204160206538111033"
+                      "version": "0.42.1.51946",
+                      "templateHash": "5534842626934673245"
                     }
                   },
                   "parameters": {
@@ -4562,8 +4548,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.41.2.15936",
-              "templateHash": "4674860099392416212"
+              "version": "0.42.1.51946",
+              "templateHash": "8805731831005341083"
             }
           },
           "parameters": {
@@ -4647,8 +4633,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.41.2.15936",
-                      "templateHash": "17548571893651101785"
+                      "version": "0.42.1.51946",
+                      "templateHash": "3327197611512448778"
                     }
                   },
                   "parameters": {
@@ -4781,8 +4767,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.41.2.15936",
-                              "templateHash": "6091329104405289493"
+                              "version": "0.42.1.51946",
+                              "templateHash": "11771554881309131596"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },


### PR DESCRIPTION
## Purpose
This pull request updates the infrastructure deployment templates to improve how the AI Foundry project's managed identity principal ID is determined, and also upgrades the Bicep template generator version throughout the deployment files. The most important changes are:

**AI Project Principal ID Output Logic:**
- Updated the logic for the `aiProjectPrincipalId` output in both `infra/deploy_ai_foundry.bicep` and the generated `infra/main.json` to reference the correct deployment output (`assignFoundryRoleToMIExisting`/`assignFoundryRoleToMI`) when an existing AI project is present, ensuring the principal ID is retrieved from the appropriate resource assignment. [[1]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L612-R612) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2410-R2410)

**Bicep Template Generator Version Upgrade:**
- Upgraded the Bicep template generator version from `0.41.2.15936` to `0.42.1.51946` across all relevant sections in `infra/main.json`, which also resulted in updated template hashes. This ensures compatibility with the latest Bicep features and bug fixes. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L7-R8) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L505-R506) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L658-R659) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1546-R1547) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1678-R1679) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1804-R1805) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2066-R2067) [[8]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2444-R2445) [[9]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2620-R2621) [[10]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2775-R2776) [[11]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2940-R2941) [[12]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3073-R3074) [[13]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3207-R3208) [[14]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3286-R3287) [[15]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3427-R3428) [[16]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3777-R3778) [[17]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3889-R3890) [[18]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4023-R4024) [[19]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4102-R4103) [[20]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4243-R4244) [[21]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4551-R4552) [[22]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4636-R4637) [[23]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4770-R4771)

These changes ensure that the managed identity principal ID is accurately outputted based on the deployment scenario and that the infrastructure codebase remains up-to-date with the latest tooling.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.