### PR TITLE
fix: update link format in CustomizingAzdParameters documentation

### DIFF
--- a/documents/CustomizingAzdParameters.md
+++ b/documents/CustomizingAzdParameters.md
@@ -19,7 +19,7 @@ By default this template will use the environment name as the prefix to prevent 
 | `AZURE_ENV_GPT_MODEL_CAPACITY`  | integer | `150`                    | Sets the GPT model capacity (minimum: 10).                                 |
 | `AZURE_ENV_IMAGE_TAG`                    | string  | `latest_workshop`        | Sets the container image tag.                                              |
 | `USE_CASE`                      | string  | `Retail-sales-analysis`  | Specifies the use case (allowed: `Retail-sales-analysis`, `Insurance-improve-customer-meetings`). |
-| `AZURE_ENV_EXISTING_LOG_ANALYTICS_WORKSPACE_RID`   | string  | ` `                      | Reuses an existing Log Analytics Workspace. Guide: [Existing Workspace ID](/documents/re-use-log-analytics.md). |
+| `AZURE_ENV_EXISTING_LOG_ANALYTICS_WORKSPACE_RID`   | string  | ` `                      | Reuses an existing Log Analytics Workspace. Guide: [Existing Workspace ID](re-use-log-analytics.md). |
 | `AZURE_EXISTING_AIPROJECT_RESOURCE_ID`   | string  | ` `                      | Reuses an existing AI Foundry project instead of creating a new one.       |
 | `BACKEND_RUNTIME_STACK`                   | string  | `python`                 | Backend language (allowed: `python`, `dotnet`).                            |
 | `AZURE_ENV_AI_SERVICE_LOCATION`       | string  |                          | Location for AI Foundry deployment (e.g., `eastus`, `swedencentral`).      |


### PR DESCRIPTION
## Purpose
This pull request makes a minor documentation update to the `CustomizingAzdParameters.md` file. The change updates a link in the guide for reusing an existing Log Analytics Workspace to use a relative path instead of an absolute one.

* Documentation:
  * Updated the link for the "Existing Workspace ID" guide in the `AZURE_ENV_EXISTING_LOG_ANALYTICS_WORKSPACE_RID` parameter to use a relative path (`re-use-log-analytics.md`) instead of an absolute path.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.