### PR TITLE
fix(docs)+feat(infra): correct QuotaCheck URL and add preprovision quota hook (Bug 42645, DOC-001)

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -13,6 +13,41 @@ metadata:
   template: agentic-applications-for-unified-data-foundation@1.1
 
 hooks:
+  preprovision:
+    windows:
+      run: |
+        Write-Host "Checking Azure OpenAI quota for required models before provisioning..." -ForegroundColor Cyan
+        $bashPath = $null
+        $candidates = @(
+            "$env:ProgramFiles\Git\bin\bash.exe",
+            "${env:ProgramFiles(x86)}\Git\bin\bash.exe",
+            "$env:LOCALAPPDATA\Programs\Git\bin\bash.exe"
+        )
+        foreach ($c in $candidates) { if ($c -and (Test-Path $c)) { $bashPath = $c; break } }
+        if (-not $bashPath) {
+            $cmd = Get-Command bash.exe -ErrorAction SilentlyContinue | Where-Object { $_.Source -notlike '*System32*' } | Select-Object -First 1
+            if ($cmd) { $bashPath = $cmd.Source }
+        }
+        if (-not $bashPath) {
+            Write-Host "bash not found. Install Git for Windows (https://git-scm.com/download/win) or run from WSL/Cloud Shell." -ForegroundColor Red
+            exit 1
+        }
+        & $bashPath ./infra/scripts/quota_check_params.sh
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Quota check failed. Aborting provisioning." -ForegroundColor Red
+            exit $LASTEXITCODE
+        }
+      shell: pwsh
+      continueOnError: false
+      interactive: true
+    posix:
+      run: |
+        echo "Checking Azure OpenAI quota for required models before provisioning..."
+        chmod +x ./infra/scripts/quota_check_params.sh
+        ./infra/scripts/quota_check_params.sh
+      shell: sh
+      continueOnError: false
+      interactive: true
   postprovision:
     windows:
       run: |

--- a/documents/QuotaCheck.md
+++ b/documents/QuotaCheck.md
@@ -66,7 +66,7 @@ The final table lists regions with available quota. You can select any of these 
    **To check quota for the deployment**  
 
     ```sh
-    curl -L -o quota_check_params.sh "https://raw.githubusercontent.com/microsoft/Conversation-Knowledge-Mining-Solution-Accelerator/main/infra/scripts/quota_check_params.sh"
+    curl -L -o quota_check_params.sh "https://raw.githubusercontent.com/microsoft/agentic-applications-for-unified-data-foundation-solution-accelerator/main/infra/scripts/quota_check_params.sh"
     chmod +x quota_check_params.sh
     ./quota_check_params.sh
     ```


### PR DESCRIPTION
## Summary

Fully addresses **Bug 42645 / DOC-001 — Quota Check Script Downloads from WRONG Repository** with two changes:

1. **`documents/QuotaCheck.md`** — Cloud Shell `curl` URL corrected to download `quota_check_params.sh` from this repo instead of `microsoft/Conversation-Knowledge-Mining-Solution-Accelerator`.
2. **`azure.yaml`** — New `preprovision` hook automatically runs `infra/scripts/quota_check_params.sh` before `azd up` provisions resources, so quota validation is enforced even when users skip the manual Cloud Shell step.

## Bug Recommendations Coverage

| # | Recommendation | Status |
|---|----------------|--------|
| 1 | Create dedicated quota check script for this accelerator's models | ✅ Already in repo: `infra/scripts/quota_check_params.sh` |
| 2 | Update documentation to reference correct repository URL | ✅ Fixed in this PR (`documents/QuotaCheck.md`) |
| 3 | Use correct model defaults (`gpt-4o:150,gpt-4o-mini:150,gpt-4:150`) | ✅ Already correct in `quota_check_params.sh` |
| 4 | Add quota validation as preprovision hook in `azure.yaml` | ✅ Added in this PR |

## Changes

### `documents/QuotaCheck.md`
Cloud Shell command now downloads from the correct repository:
```bash
curl -L https://raw.githubusercontent.com/microsoft/agentic-applications-for-unified-data-foundation-solution-accelerator/main/infra/scripts/quota_check_params.sh -o quota_check_params.sh
```

### `azure.yaml` — new `preprovision` hook
- **Windows (`pwsh`)**: auto-discovers Git Bash (`Program Files\Git\bin\bash.exe`, etc.), with a clear error if not found, and invokes the script.
- **POSIX (`sh`)**: chmod +x and run directly.
- `continueOnError: false` — quota failures abort provisioning.
- `interactive: true` — allows the script's subscription-selection prompt when multiple subscriptions are present.

## Verification

**Doc fix:**
```bash
$ curl -L https://raw.githubusercontent.com/microsoft/agentic-applications-for-unified-data-foundation-solution-accelerator/main/infra/scripts/quota_check_params.sh -o quota_check_params.sh
$ head -1 quota_check_params.sh
#!/bin/bash
```

**Preprovision hook:** ran `azd hooks run preprovision` against subscription `CSA-CTO-Engineering-Maintenance`. The hook successfully invoked the script and printed the full quota table for `gpt-4o`, `gpt-4o-mini`, and `gpt-4` across the 6 default regions (`eastus`, `eastus2`, `australiaeast`, `uksouth`, `francecentral`, `westus`) with exit code 0.

## Risk

- **Low** for the doc fix — string-only change.
- **Low–medium** for the hook — runs only during `azd up` preprovision; uses the same script that documentation already recommends. `continueOnError: false` means a quota miss will block provisioning (the intended behavior). Windows users without Git Bash get a clear actionable error.

## References

- ADO Bug: [42645](https://dev.azure.com/CSACTOSOL/DATA%20-%20ACCL%20-%20MAAG%20RTI/_workitems/edit/42645)
- Identifier: DOC-001
