### PR TITLE
feat: Added logic to create workspace based on the flag set in bicep

### DIFF
--- a/infra/abbreviations.json
+++ b/infra/abbreviations.json
@@ -95,6 +95,9 @@
     "serviceFabricCluster": "sf-",
     "serviceFabricManagedCluster": "sfmc-"
   },
+  "fabric": {
+    "fabricCapacity": "fc"
+  },
   "databases": {
     "cosmosDBDatabase": "cosmos-",
     "cosmosDBApacheCassandra": "coscas-",

--- a/infra/deploy_fabric_capacity.bicep
+++ b/infra/deploy_fabric_capacity.bicep
@@ -1,0 +1,42 @@
+// ========== deploy_fabric_capacity.bicep ========== //
+// Deploys a Microsoft Fabric capacity resource.
+
+@description('Name of the Fabric capacity resource.')
+param capacityName string
+
+@description('Location for the Fabric capacity resource.')
+param solutionLocation string
+
+@description('SKU name for the Fabric capacity (e.g., F2, F4, F8, F16, F32, F64).')
+@allowed([
+  'F2'
+  'F4'
+  'F8'
+  'F16'
+  'F32'
+  'F64'
+])
+param skuName string = 'F8'
+
+@description('Array of admin member UPNs or object IDs for the Fabric capacity.')
+param adminMembers array
+
+resource fabricCapacity 'Microsoft.Fabric/capacities@2023-11-01' = {
+  name: capacityName
+  location: solutionLocation
+  sku: {
+    name: skuName
+    tier: 'Fabric'
+  }
+  properties: {
+    administration: {
+      members: adminMembers
+    }
+  }
+}
+
+@description('Resource ID of the deployed Fabric capacity.')
+output capacityId string = fabricCapacity.id
+
+@description('Name of the deployed Fabric capacity.')
+output capacityName string = fabricCapacity.name

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -90,6 +90,20 @@ param isWorkshop bool = true
 @description('Set to true to deploy Azure SQL Server, otherwise Fabric SQL is used.')
 param azureEnvOnly bool = false
 
+@description('Set to true to create a new Fabric capacity and workspace for workshop mode. When false, an existing FABRIC_WORKSPACE_ID must be provided.')
+param createFabricWorkspace bool = false
+
+@description('SKU for the Fabric capacity resource. Only used when createFabricWorkspace is true.')
+@allowed([
+  'F2'
+  'F4'
+  'F8'
+  'F16'
+  'F32'
+  'F64'
+])
+param fabricCapacitySku string = 'F8'
+
 @description('Enable chat history.')
 param useChatHistoryEnabled bool = true
 
@@ -155,6 +169,19 @@ var existingTags = resourceGroup().tags ?? {}
 @description('The principal type of the deploying user. Use ServicePrincipal for CI/CD pipelines with OIDC.')
 @allowed(['User', 'ServicePrincipal'])
 param deployingUserPrincipalType string = 'User'
+
+// ========== Fabric Capacity (optional, for workshop mode) ========== //
+var fabricCapacityAdminMembers = contains(deployerInfo, 'userPrincipalName') ? [deployerInfo.userPrincipalName] : []
+module fabricCapacityModule 'deploy_fabric_capacity.bicep' = if (createFabricWorkspace) {
+  name: 'deploy_fabric_capacity'
+  params: {
+    capacityName: '${abbrs.fabric.fabricCapacity}${solutionSuffix}'
+    solutionLocation: solutionLocation
+    skuName: fabricCapacitySku
+    adminMembers: fabricCapacityAdminMembers
+  }
+  scope: resourceGroup(resourceGroup().name)
+}
 
 // ========== Resource Group Tag ========== //
 resource resourceGroupTags 'Microsoft.Resources/tags@2023-07-01' = if (!isWorkshop) {
@@ -482,3 +509,12 @@ output AZURE_ENV_ONLY bool = azureEnvOnly
 
 @description('Flag indicating whether user access token forwarding is enabled')
 output USE_USER_ACCESS_TOKEN string = useUserAccessTokenSetting
+
+@description('Flag indicating whether to create a new Fabric workspace')
+output CREATE_FABRIC_WORKSPACE bool = createFabricWorkspace
+
+@description('Resource ID of the deployed Fabric capacity (empty when createFabricWorkspace is false)')
+output FABRIC_CAPACITY_ID string = createFabricWorkspace ? fabricCapacityModule!.outputs.capacityId : ''
+
+@description('Name of the deployed Fabric capacity (empty when createFabricWorkspace is false)')
+output FABRIC_CAPACITY_NAME string = createFabricWorkspace ? fabricCapacityModule!.outputs.capacityName : ''

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "3645839045207447954"
+      "templateHash": "8612344795394675897"
     }
   },
   "parameters": {
@@ -169,6 +169,28 @@
       "defaultValue": false,
       "metadata": {
         "description": "Set to true to deploy Azure SQL Server, otherwise Fabric SQL is used."
+      }
+    },
+    "createFabricWorkspace": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Set to true to create a new Fabric capacity and workspace for workshop mode. When false, an existing FABRIC_WORKSPACE_ID must be provided."
+      }
+    },
+    "fabricCapacitySku": {
+      "type": "string",
+      "defaultValue": "F8",
+      "allowedValues": [
+        "F2",
+        "F4",
+        "F8",
+        "F16",
+        "F32",
+        "F64"
+      ],
+      "metadata": {
+        "description": "SKU for the Fabric capacity resource. Only used when createFabricWorkspace is true."
       }
     },
     "useChatHistoryEnabled": {
@@ -344,6 +366,9 @@
         "serviceFabricCluster": "sf-",
         "serviceFabricManagedCluster": "sfmc-"
       },
+      "fabric": {
+        "fabricCapacity": "fc"
+      },
       "databases": {
         "cosmosDBDatabase": "cosmos-",
         "cosmosDBApacheCassandra": "coscas-",
@@ -485,6 +510,7 @@
     "deployerInfo": "[deployer()]",
     "deployingUserPrincipalId": "[variables('deployerInfo').objectId]",
     "existingTags": "[coalesce(resourceGroup().tags, createObject())]",
+    "fabricCapacityAdminMembers": "[if(contains(variables('deployerInfo'), 'userPrincipalName'), createArray(variables('deployerInfo').userPrincipalName), createArray())]",
     "landingText": "[if(equals(parameters('usecase'), 'Retail-sales-analysis'), 'You can ask questions around sales, products and orders.', 'You can ask questions around customer policies, claims and communications.')]"
   },
   "resources": [
@@ -495,6 +521,112 @@
       "name": "default",
       "properties": {
         "tags": "[union(variables('existingTags'), createObject('TemplateName', 'Unified Data Analysis Agents', 'CreatedBy', parameters('createdBy'), 'DeploymentName', deployment().name, 'Type', 'Non-WAF'))]"
+      }
+    },
+    {
+      "condition": "[parameters('createFabricWorkspace')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "deploy_fabric_capacity",
+      "resourceGroup": "[resourceGroup().name]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "capacityName": {
+            "value": "[format('{0}{1}', variables('abbrs').fabric.fabricCapacity, variables('solutionSuffix'))]"
+          },
+          "solutionLocation": {
+            "value": "[variables('solutionLocation')]"
+          },
+          "skuName": {
+            "value": "[parameters('fabricCapacitySku')]"
+          },
+          "adminMembers": {
+            "value": "[variables('fabricCapacityAdminMembers')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.42.1.51946",
+              "templateHash": "13459595293541482427"
+            }
+          },
+          "parameters": {
+            "capacityName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the Fabric capacity resource."
+              }
+            },
+            "solutionLocation": {
+              "type": "string",
+              "metadata": {
+                "description": "Location for the Fabric capacity resource."
+              }
+            },
+            "skuName": {
+              "type": "string",
+              "defaultValue": "F8",
+              "allowedValues": [
+                "F2",
+                "F4",
+                "F8",
+                "F16",
+                "F32",
+                "F64"
+              ],
+              "metadata": {
+                "description": "SKU name for the Fabric capacity (e.g., F2, F4, F8, F16, F32, F64)."
+              }
+            },
+            "adminMembers": {
+              "type": "array",
+              "metadata": {
+                "description": "Array of admin member UPNs or object IDs for the Fabric capacity."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Fabric/capacities",
+              "apiVersion": "2023-11-01",
+              "name": "[parameters('capacityName')]",
+              "location": "[parameters('solutionLocation')]",
+              "sku": {
+                "name": "[parameters('skuName')]",
+                "tier": "Fabric"
+              },
+              "properties": {
+                "administration": {
+                  "members": "[parameters('adminMembers')]"
+                }
+              }
+            }
+          ],
+          "outputs": {
+            "capacityId": {
+              "type": "string",
+              "metadata": {
+                "description": "Resource ID of the deployed Fabric capacity."
+              },
+              "value": "[resourceId('Microsoft.Fabric/capacities', parameters('capacityName'))]"
+            },
+            "capacityName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the deployed Fabric capacity."
+              },
+              "value": "[parameters('capacityName')]"
+            }
+          }
+        }
       }
     },
     {
@@ -678,7 +810,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "16848402676405380264"
+              "templateHash": "16258553752543885674"
             }
           },
           "parameters": {
@@ -889,6 +1021,9 @@
                 "containerInstance": "ci",
                 "serviceFabricCluster": "sf-",
                 "serviceFabricManagedCluster": "sfmc-"
+              },
+              "fabric": {
+                "fabricCapacity": "fc"
               },
               "databases": {
                 "cosmosDBDatabase": "cosmos-",
@@ -5140,6 +5275,27 @@
         "description": "Flag indicating whether user access token forwarding is enabled"
       },
       "value": "[variables('useUserAccessTokenSetting')]"
+    },
+    "CREATE_FABRIC_WORKSPACE": {
+      "type": "bool",
+      "metadata": {
+        "description": "Flag indicating whether to create a new Fabric workspace"
+      },
+      "value": "[parameters('createFabricWorkspace')]"
+    },
+    "FABRIC_CAPACITY_ID": {
+      "type": "string",
+      "metadata": {
+        "description": "Resource ID of the deployed Fabric capacity (empty when createFabricWorkspace is false)"
+      },
+      "value": "[if(parameters('createFabricWorkspace'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_fabric_capacity'), '2025-04-01').outputs.capacityId.value, '')]"
+    },
+    "FABRIC_CAPACITY_NAME": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the deployed Fabric capacity (empty when createFabricWorkspace is false)"
+      },
+      "value": "[if(parameters('createFabricWorkspace'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', 'deploy_fabric_capacity'), '2025-04-01').outputs.capacityName.value, '')]"
     }
   }
 }

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -61,6 +61,12 @@
     },
     "deployingUserPrincipalType": {
       "value": "${DEPLOYING_USER_PRINCIPAL_TYPE=User}"
+    },
+    "useUserAccessToken":{
+      "value": "${USE_USER_ACCESS_TOKEN}"
+    },
+    "createFabricWorkspace": {
+      "value": "${CREATE_FABRIC_WORKSPACE}"
     }
   }
 }

--- a/scripts/.env
+++ b/scripts/.env
@@ -13,7 +13,7 @@ AZURE_ENV_DEPLOY_APP=true
 USE_DATA_AGENT=false
 
 # --- Microsoft Fabric (required) ---
-FABRIC_WORKSPACE_ID=your-workspace-id-here
+FABRIC_WORKSPACE_ID=
 
 # Solution name prefix (optional - defaults to AZURE_ENV_NAME from azd)
 # SOLUTION_NAME=myproject

--- a/scripts/00_build_solution.py
+++ b/scripts/00_build_solution.py
@@ -299,8 +299,9 @@ for step in pipeline:
 # ============================================================================
 
 if not azure_only:
+    create_fabric_workspace = os.getenv("CREATE_FABRIC_WORKSPACE", "false").lower() == "true"
     fabric_workspace_id = args.fabric_workspace_id or os.getenv("FABRIC_WORKSPACE_ID", "").strip()
-    if not fabric_workspace_id:
+    if not fabric_workspace_id and not create_fabric_workspace:
         print("\n" + "="*60)
         print("Fabric Workspace Configuration")
         print("="*60)
@@ -310,14 +311,18 @@ if not azure_only:
         if not fabric_workspace_id:
             print("ERROR: Fabric Workspace ID is required in Fabric mode.")
             print("       Pass --fabric-workspace-id <id> or set FABRIC_WORKSPACE_ID in .env")
+            print("       Or set CREATE_FABRIC_WORKSPACE=true to auto-create a workspace.")
             print("       Or use AZURE_ENV_ONLY=true for Azure SQL mode.")
             sys.exit(1)
-    # Make it available to downstream scripts
-    os.environ["FABRIC_WORKSPACE_ID"] = fabric_workspace_id
-    # Persist to scripts/.env so subsequent runs don't need to re-enter it
-    from dotenv import set_key
-    env_path = os.path.join(script_dir, ".env")
-    set_key(env_path, "FABRIC_WORKSPACE_ID", fabric_workspace_id)
+    if fabric_workspace_id:
+        # Make it available to downstream scripts
+        os.environ["FABRIC_WORKSPACE_ID"] = fabric_workspace_id
+        # Persist to scripts/.env so subsequent runs don't need to re-enter it
+        from dotenv import set_key
+        env_path = os.path.join(script_dir, ".env")
+        set_key(env_path, "FABRIC_WORKSPACE_ID", fabric_workspace_id)
+    elif create_fabric_workspace:
+        print("  (Workspace will be auto-created by step 02)")
 
 # ============================================================================
 # Interactive Prompts for Data Generation

--- a/scripts/02_create_fabric_items.py
+++ b/scripts/02_create_fabric_items.py
@@ -54,9 +54,12 @@ p.add_argument("--datasource-type", choices=["ontology", "lakehouse"], default="
                help="Data source type for Data Agent: 'ontology' or 'lakehouse' (default)")
 args = p.parse_args()
 
+CREATE_FABRIC_WORKSPACE = os.getenv("CREATE_FABRIC_WORKSPACE", "false").lower() == "true"
 WORKSPACE_ID = os.getenv("FABRIC_WORKSPACE_ID")
-if not WORKSPACE_ID:
+
+if not WORKSPACE_ID and not CREATE_FABRIC_WORKSPACE:
     print("ERROR: FABRIC_WORKSPACE_ID not set in .env")
+    print("       Set FABRIC_WORKSPACE_ID or set CREATE_FABRIC_WORKSPACE=true to auto-create a workspace.")
     sys.exit(1)
 
 # Get data folder - use arg if provided, else from .env with proper path resolution
@@ -100,7 +103,8 @@ with open(config_path) as f:
 print(f"\n{'='*60}")
 print(f"Setting up Fabric for: {SOLUTION_NAME}")
 print(f"{'='*60}")
-print(f"Workspace ID: {WORKSPACE_ID}")
+print(f"Workspace ID: {WORKSPACE_ID or '(will be created)'}")
+print(f"Create Fabric Workspace: {CREATE_FABRIC_WORKSPACE}")
 print(f"Scenario: {ontology_config['name']}")
 print(f"Datasource type: {args.datasource_type}")
 print(f"Tables: {', '.join(ontology_config['tables'].keys())}")
@@ -268,6 +272,100 @@ def b64encode(content):
     if isinstance(content, str):
         content = content.encode("utf-8")
     return base64.b64encode(content).decode("utf-8")
+
+# ============================================================================
+# Workspace creation and capacity assignment (when CREATE_FABRIC_WORKSPACE is true)
+# ============================================================================
+
+if CREATE_FABRIC_WORKSPACE:
+    FABRIC_CAPACITY_ID = os.getenv("FABRIC_CAPACITY_ID")
+    if not FABRIC_CAPACITY_ID:
+        print("ERROR: FABRIC_CAPACITY_ID not set. Deploy with createFabricWorkspace=true first.")
+        sys.exit(1)
+
+    # Step A: Create workspace if it doesn't exist yet
+    if not WORKSPACE_ID:
+        ws_display_name = f"workspace-{SOLUTION_NAME}"
+        print(f"\n[AUTO] Creating Fabric workspace: {ws_display_name}")
+
+        # Check if workspace already exists
+        list_resp = make_request("GET", f"{FABRIC_API}/workspaces")
+        if list_resp.status_code == 200:
+            for ws in list_resp.json().get("value", []):
+                if ws["displayName"] == ws_display_name:
+                    WORKSPACE_ID = ws["id"]
+                    print(f"  [OK] Reusing existing workspace: {WORKSPACE_ID}")
+                    break
+
+        if not WORKSPACE_ID:
+            create_resp = make_request("POST", f"{FABRIC_API}/workspaces", json={
+                "displayName": ws_display_name,
+                "description": f"Auto-created workspace for {SOLUTION_NAME}"
+            })
+            if create_resp.status_code in [200, 201]:
+                WORKSPACE_ID = create_resp.json()["id"]
+                print(f"  [OK] Created workspace: {WORKSPACE_ID}")
+            else:
+                print(f"ERROR: Failed to create workspace: {create_resp.status_code} {create_resp.text}")
+                sys.exit(1)
+
+        # Persist workspace ID to scripts/.env for future runs and refresh in-process env
+        env_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env")
+        os.environ["FABRIC_WORKSPACE_ID"] = WORKSPACE_ID
+        with open(env_file, "r") as f:
+            env_content = f.read()
+        if "FABRIC_WORKSPACE_ID" not in env_content:
+            with open(env_file, "a") as f:
+                f.write(f"\nFABRIC_WORKSPACE_ID={WORKSPACE_ID}\n")
+            print(f"  [OK] Saved FABRIC_WORKSPACE_ID to scripts/.env")
+        else:
+            import re
+            updated = re.sub(r'^FABRIC_WORKSPACE_ID=.*$', f'FABRIC_WORKSPACE_ID={WORKSPACE_ID}', env_content, flags=re.MULTILINE)
+            with open(env_file, "w") as f:
+                f.write(updated)
+            print(f"  [OK] Updated FABRIC_WORKSPACE_ID in scripts/.env")
+
+    # Step B: Check if capacity is already assigned, assign if not
+    ws_resp = make_request("GET", f"{FABRIC_API}/workspaces/{WORKSPACE_ID}")
+    if ws_resp.status_code == 200:
+        ws_capacity = ws_resp.json().get("capacityId", "")
+    else:
+        ws_capacity = ""
+
+    if ws_capacity:
+        print(f"  [OK] Workspace already has capacity assigned: {ws_capacity}")
+    else:
+        # Resolve FABRIC_CAPACITY_ID to a GUID if it's an ARM resource ID
+        capacity_guid = FABRIC_CAPACITY_ID
+        if "/" in FABRIC_CAPACITY_ID:
+            capacity_name = FABRIC_CAPACITY_ID.rstrip("/").split("/")[-1]
+            print(f"  Resolving capacity name '{capacity_name}' to GUID...")
+            cap_resp = make_request("GET", f"{FABRIC_API}/capacities")
+            if cap_resp.status_code == 200:
+                for cap in cap_resp.json().get("value", []):
+                    if cap.get("displayName", "").lower() == capacity_name.lower():
+                        capacity_guid = cap["id"]
+                        print(f"  [OK] Resolved capacity GUID: {capacity_guid}")
+                        break
+                else:
+                    print(f"  [WARN] Could not find capacity '{capacity_name}' in Fabric API. Trying raw ID.")
+            else:
+                print(f"  [WARN] Failed to list capacities: {cap_resp.status_code}. Trying raw ID.")
+
+        print(f"  Assigning capacity to workspace...")
+        assign_resp = make_request("POST", f"{FABRIC_API}/workspaces/{WORKSPACE_ID}/assignToCapacity", json={
+            "capacityId": capacity_guid
+        })
+        if assign_resp.status_code in [200, 202]:
+            print(f"  [OK] Capacity assigned to workspace")
+        elif assign_resp.status_code == 409:
+            print(f"  [OK] Workspace already assigned to a capacity")
+        else:
+            print(f"  [FAIL] Capacity assignment failed: {assign_resp.status_code}: {assign_resp.text}")
+            print(f"         Lakehouse requires an assigned capacity. Fix FABRIC_CAPACITY_ID and retry.")
+            sys.exit(1)
+
+print(f"Workspace ID: {WORKSPACE_ID}")
 
 # ============================================================================
 # Step 0: Determine lakehouse/ontology names (use local tracking, minimize API calls)
@@ -477,7 +575,7 @@ create_url = f"{FABRIC_API}/workspaces/{WORKSPACE_ID}/items"
 # Retry notebook creation in case the name is not yet released after deletion
 for nb_attempt in range(5):
     resp = make_request("POST", create_url, json=create_nb_payload)
-    if resp.status_code == 400 and "NotAvailableYet" in resp.text:
+    if resp.status_code in [400, 409] and "NotAvailableYet" in resp.text:
         wait_secs = 15 * (nb_attempt + 1)
         print(f"  Name not released yet (attempt {nb_attempt+1}/5). Waiting {wait_secs}s...")
         time.sleep(wait_secs)

--- a/scripts/generate_env_from_azure.py
+++ b/scripts/generate_env_from_azure.py
@@ -84,6 +84,15 @@ def get_resources_by_type(resource_group: str, resource_type: str) -> list:
     return result if isinstance(result, list) else []
 
 
+def get_fabric_capacity(resource_group: str) -> tuple[str, str]:
+    """Get Fabric capacity resource ID and name, if one exists in the resource group."""
+    resources = get_resources_by_type(resource_group, "Microsoft.Fabric/capacities")
+    if resources:
+        capacity = resources[0]
+        return capacity.get("id", ""), capacity.get("name", "")
+    return "", ""
+
+
 def get_ai_search_endpoint(resource_group: str) -> tuple[str, str]:
     """Get Azure AI Search endpoint and name."""
     resources = get_resources_by_type(resource_group, "Microsoft.Search/searchServices")
@@ -442,6 +451,18 @@ def generate_env_from_app_service(resource_group: str, app_name: str) -> str | N
         if key not in important_vars:
             if key.startswith("AZURE_") or key.startswith("AI_") or key.startswith("SQL"):
                 lines.append(f"{key}={value}")
+
+    # Check for Fabric capacity in the resource group
+    fabric_capacity_id, fabric_capacity_name = get_fabric_capacity(resource_group)
+    if fabric_capacity_id:
+        _log(f"  Found Fabric capacity: {fabric_capacity_name}")
+        lines.extend([
+            "",
+            "# --- Fabric Capacity (auto-detected) ---",
+            f"CREATE_FABRIC_WORKSPACE=true",
+            f"FABRIC_CAPACITY_ID={fabric_capacity_id}",
+            f"FABRIC_CAPACITY_NAME={fabric_capacity_name}",
+        ])
     
     return "\n".join(lines)
 
@@ -492,6 +513,9 @@ def generate_env_content(resource_group: str) -> str:
     mid_name, mid_client_id, mid_principal_id = get_managed_identity(resource_group)
     _log(f"  Found Managed Identity: {mid_name or 'not found'}")
     
+    fabric_capacity_id, fabric_capacity_name = get_fabric_capacity(resource_group)
+    _log(f"  Found Fabric capacity: {fabric_capacity_name or 'not found'}")
+
     web_app_url, _ = get_app_service(resource_group, "app-")
     if not web_app_url:
         # Frontend app may be named app-<suffix> (not containing "web")
@@ -555,6 +579,16 @@ def generate_env_content(resource_group: str) -> str:
         "IS_WORKSHOP=true",
         "USE_CASE=Network operations with outage tracking and trouble ticket management",
     ]
+
+    # Add Fabric capacity settings if a capacity resource was found
+    if fabric_capacity_id:
+        lines.extend([
+            "",
+            "# --- Fabric Capacity (auto-detected) ---",
+            f"CREATE_FABRIC_WORKSPACE=true",
+            f"FABRIC_CAPACITY_ID={fabric_capacity_id}",
+            f"FABRIC_CAPACITY_NAME={fabric_capacity_name}",
+        ])
     
     return "\n".join(lines)
 
@@ -563,7 +597,9 @@ def get_default_env_content() -> str:
     """Get default env content for new .env files (Fabric settings, agent IDs, etc.)."""
     lines = [
         "",
-        "# --- Fabric Settings (fill in manually) ---",
+        "# --- Fabric Settings ---",
+        "# FABRIC_WORKSPACE_ID is auto-created when CREATE_FABRIC_WORKSPACE=true,",
+        "# otherwise set it manually to an existing workspace ID.",
         "FABRIC_WORKSPACE_ID=",
         "DATA_FOLDER=data/default",
         "INDUSTRY=Telecommunications",


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request introduces support for automatic creation and assignment of Microsoft Fabric capacity and workspace resources during deployment, particularly for workshop or demo scenarios. The changes add new parameters and logic to the infrastructure templates and deployment scripts, enabling a fully automated Fabric setup when `CREATE_FABRIC_WORKSPACE` is set to `true`. Manual entry of `FABRIC_WORKSPACE_ID` is no longer required if auto-creation is enabled, and the scripts handle workspace creation, capacity deployment, and assignment seamlessly.

The most important changes are:

**Infrastructure as Code (Bicep/ARM/JSON):**
* Added a new module (`deploy_fabric_capacity.bicep`) and corresponding ARM template logic to deploy a Microsoft Fabric capacity resource, with configurable SKU and admin members. [[1]](diffhunk://#diff-2ff20bd59e72b57bf66fea04309ce336ddecada35b218ea8ffddd22c9ba65da5R1-R42) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R526-R631)
* Introduced new parameters (`createFabricWorkspace`, `fabricCapacitySku`) and outputs (`FABRIC_CAPACITY_ID`, `FABRIC_CAPACITY_NAME`, `CREATE_FABRIC_WORKSPACE`) to control and expose Fabric capacity deployment in `main.bicep`, `main.json`, and `main.parameters.json`. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R93-R106) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R174-R195) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R5278-R5298) [[4]](diffhunk://#diff-834bc11e3cb55730076a7d70767b75f794dc9a37305f27d99926e0fd24363c13R64-R69)
* Updated abbreviations and variables to support Fabric capacity naming conventions. [[1]](diffhunk://#diff-9aec7ee0c337f1a433200c8cfd4c54258d9acb0a66ebd717f83d705dd4dafba1R98-R100) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R369-R371) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R1025-R1027)

**Deployment Script Enhancements:**
* Updated `00_build_solution.py` and `02_create_fabric_items.py` to support auto-creation of Fabric workspaces and to handle cases where the workspace ID is not pre-supplied but auto-creation is enabled. Clear error messages and guidance are provided if required values are missing. [[1]](diffhunk://#diff-677d48ac6f8bf8159f2437b1e62b5215a0a5665889d86986a07fc23f4ccc6d1aR302-R304) [[2]](diffhunk://#diff-677d48ac6f8bf8159f2437b1e62b5215a0a5665889d86986a07fc23f4ccc6d1aR314-R325) [[3]](diffhunk://#diff-efafe2c569d1545a837f0fd7d663685081c8922b46edba3f1dc9865fcf1aa7a8R57-R62) [[4]](diffhunk://#diff-efafe2c569d1545a837f0fd7d663685081c8922b46edba3f1dc9865fcf1aa7a8L103-R107)
* Implemented logic in `02_create_fabric_items.py` to create a Fabric workspace if it does not exist, persist its ID, and assign it to the deployed capacity, including robust checks and status messages.

**Configuration and Environment:**
* Updated `.env` and script environment handling to support the new workflow and ensure correct propagation of workspace and capacity IDs.

These changes streamline the deployment process for scenarios requiring Microsoft Fabric, reducing manual configuration and enabling reproducible, automated setups.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

