### PR TITLE
fix: Restrict deploy workflow to manual trigger only

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -2,13 +2,6 @@ name: Azure Dev Deploy
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'infra/**'
-      - 'azure.yaml'
-      - '.github/workflows/azure-dev.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Removes `push` and/or `pull_request` triggers from the deploy workflow (`azure-dev.yml`). The workflow now only runs via `workflow_dispatch` (manual trigger).

## Why
The workflow runs `azd up` which provisions Azure resources. Auto-triggering on every push/PR causes unintended resource provisioning without cleanup, leading to orphaned resource groups and unnecessary costs.