### PR TITLE
refactor: Updated Foundry Roles name

### DIFF
--- a/documents/LocalDevelopmentSetup.md
+++ b/documents/LocalDevelopmentSetup.md
@@ -278,10 +278,10 @@ To run the application locally, your Azure account needs the following role assi
 # Get your principal ID
 PRINCIPAL_ID=$(az ad signed-in-user show --query id -o tsv)
 
-# Assign Azure AI User role
+# Assign Foundry User role
 az role assignment create \
   --assignee $PRINCIPAL_ID \
-  --role "Azure AI User" \
+  --role "Foundry User" \
   --scope "\subscriptions\<subscription-id>\resourceGroups\<resource-group>\providers\Microsoft.CognitiveServices\accounts\<ai-foundry-account>"
 ```
 
@@ -290,10 +290,10 @@ az role assignment create \
 # Get your principal ID
 $PRINCIPAL_ID = az ad signed-in-user show --query id -o tsv
 
-# Assign Azure AI User role
+# Assign Foundry User role
 az role assignment create `
   --assignee $PRINCIPAL_ID `
-  --role "Azure AI User" `
+  --role "Foundry User" `
   --scope "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.CognitiveServices/accounts/<ai-foundry-account>"
 ```
 

--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -286,7 +286,7 @@ resource appInsightsConnection 'Microsoft.CognitiveServices/accounts/projects/co
 
 resource azureAIUser 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
   scope: subscription()
-  name: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Azure AI User
+  name: '53ca6127-db72-4b80-b1b0-d745d6d5456d' // Foundry User
 }
 
 resource cognitiveServicesOpenAIUser 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
@@ -517,7 +517,7 @@ resource userAIServicesAccess 'Microsoft.Authorization/roleAssignments@2022-04-0
   }
 }
 
-// Grant deploying user Azure AI User role on AI Services
+// Grant deploying user Foundry User role on AI Services
 resource userAzureAIAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (empty(azureExistingAIProjectResourceId)) {
   scope: aiServices
   name: guid(aiServices.id, deployingUserPrincipalId, azureAIUser.id)

--- a/infra/main.json
+++ b/infra/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.42.1.51946",
-      "templateHash": "4823159818018171492"
+      "version": "0.43.8.12551",
+      "templateHash": "11199304878133671437"
     }
   },
   "parameters": {
@@ -530,8 +530,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "16599617067634025517"
+              "version": "0.43.8.12551",
+              "templateHash": "13536969934887418432"
             }
           },
           "parameters": {
@@ -683,8 +683,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "16848402676405380264"
+              "version": "0.43.8.12551",
+              "templateHash": "2549135792664853974"
             }
           },
           "parameters": {
@@ -1571,8 +1571,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "9737384618167428949"
+                      "version": "0.43.8.12551",
+                      "templateHash": "8325817338129258671"
                     }
                   },
                   "parameters": {
@@ -1703,8 +1703,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "563276668960385803"
+                      "version": "0.43.8.12551",
+                      "templateHash": "5149350788597687463"
                     }
                   },
                   "parameters": {
@@ -1829,8 +1829,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "5534842626934673245"
+                      "version": "0.43.8.12551",
+                      "templateHash": "3195854664465026554"
                     }
                   },
                   "parameters": {
@@ -2091,8 +2091,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "5534842626934673245"
+                      "version": "0.43.8.12551",
+                      "templateHash": "3195854664465026554"
                     }
                   },
                   "parameters": {
@@ -2469,8 +2469,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "5276047402530342059"
+              "version": "0.43.8.12551",
+              "templateHash": "11610267304629320537"
             }
           },
           "parameters": {
@@ -2645,8 +2645,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "13789806692563246245"
+              "version": "0.43.8.12551",
+              "templateHash": "11421679036623536575"
             }
           },
           "parameters": {
@@ -2800,8 +2800,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "14100113989210974449"
+              "version": "0.43.8.12551",
+              "templateHash": "9298238518588007961"
             },
             "description": "Creates an Azure App Service plan."
           },
@@ -2967,8 +2967,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "17825916261368127000"
+              "version": "0.43.8.12551",
+              "templateHash": "9281355067833032374"
             }
           },
           "parameters": {
@@ -3055,7 +3055,7 @@
             "existingAIServicesName": "[if(not(empty(parameters('azureExistingAIProjectResourceId'))), split(parameters('azureExistingAIProjectResourceId'), '/')[8], '')]",
             "existingAIProjectName": "[if(not(empty(parameters('azureExistingAIProjectResourceId'))), split(parameters('azureExistingAIProjectResourceId'), '/')[10], '')]",
             "imageName": "[format('DOCKER|{0}.azurecr.io/da-api:{1}', parameters('acrName'), parameters('imageTag'))]",
-            "reactAppLayoutConfig": "{\r\n  \"appConfig\": {\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 70,\r\n        \"CHATHISTORY\": 30\r\n      }\r\n    }\r\n  }\r\n}"
+            "reactAppLayoutConfig": "{\n  \"appConfig\": {\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 70,\n        \"CHATHISTORY\": 30\n      }\n    }\n  }\n}"
           },
           "resources": [
             {
@@ -3122,8 +3122,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "3327197611512448778"
+                      "version": "0.43.8.12551",
+                      "templateHash": "14104382466378662772"
                     }
                   },
                   "parameters": {
@@ -3256,8 +3256,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.42.1.51946",
-                              "templateHash": "11771554881309131596"
+                              "version": "0.43.8.12551",
+                              "templateHash": "17534924770579664742"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -3335,8 +3335,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "9737384618167428949"
+                      "version": "0.43.8.12551",
+                      "templateHash": "8325817338129258671"
                     }
                   },
                   "parameters": {
@@ -3476,8 +3476,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "5534842626934673245"
+                      "version": "0.43.8.12551",
+                      "templateHash": "3195854664465026554"
                     }
                   },
                   "parameters": {
@@ -3826,8 +3826,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "15675271098519791556"
+              "version": "0.43.8.12551",
+              "templateHash": "1695718054370591906"
             }
           },
           "parameters": {
@@ -3900,7 +3900,7 @@
             "existingAIServicesName": "[if(not(empty(parameters('azureExistingAIProjectResourceId'))), split(parameters('azureExistingAIProjectResourceId'), '/')[8], '')]",
             "existingAIProjectName": "[if(not(empty(parameters('azureExistingAIProjectResourceId'))), split(parameters('azureExistingAIProjectResourceId'), '/')[10], '')]",
             "imageName": "[format('DOCKER|{0}.azurecr.io/da-api-dotnet:{1}', parameters('acrName'), parameters('imageTag'))]",
-            "reactAppLayoutConfig": "{\r\n  \"appConfig\": {\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 70,\r\n        \"CHATHISTORY\": 30\r\n      }\r\n    }\r\n  }\r\n}"
+            "reactAppLayoutConfig": "{\n  \"appConfig\": {\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 70,\n        \"CHATHISTORY\": 30\n      }\n    }\n  }\n}"
           },
           "resources": [
             {
@@ -3938,8 +3938,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "3327197611512448778"
+                      "version": "0.43.8.12551",
+                      "templateHash": "14104382466378662772"
                     }
                   },
                   "parameters": {
@@ -4072,8 +4072,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.42.1.51946",
-                              "templateHash": "11771554881309131596"
+                              "version": "0.43.8.12551",
+                              "templateHash": "17534924770579664742"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -4151,8 +4151,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "9737384618167428949"
+                      "version": "0.43.8.12551",
+                      "templateHash": "8325817338129258671"
                     }
                   },
                   "parameters": {
@@ -4292,8 +4292,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "5534842626934673245"
+                      "version": "0.43.8.12551",
+                      "templateHash": "3195854664465026554"
                     }
                   },
                   "parameters": {
@@ -4602,8 +4602,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.42.1.51946",
-              "templateHash": "8805731831005341083"
+              "version": "0.43.8.12551",
+              "templateHash": "9801304925244287291"
             }
           },
           "parameters": {
@@ -4687,8 +4687,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.42.1.51946",
-                      "templateHash": "3327197611512448778"
+                      "version": "0.43.8.12551",
+                      "templateHash": "14104382466378662772"
                     }
                   },
                   "parameters": {
@@ -4821,8 +4821,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.42.1.51946",
-                              "templateHash": "11771554881309131596"
+                              "version": "0.43.8.12551",
+                              "templateHash": "17534924770579664742"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },

--- a/infra/scripts/agent_scripts/run_create_agents_scripts.sh
+++ b/infra/scripts/agent_scripts/run_create_agents_scripts.sh
@@ -192,7 +192,7 @@ fi
 echo "Getting signed in user id"
 signed_user_id=$(az ad signed-in-user show --query id -o tsv) || signed_user_id=${AZURE_CLIENT_ID}
 
-echo "Checking if the user has Azure AI User role on the AI Foundry"
+echo "Checking if the user has Foundry User role on the AI Foundry"
 role_assignment=$(MSYS_NO_PATHCONV=1 az role assignment list \
   --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" \
   --scope "$aiFoundryResourceId" \
@@ -200,7 +200,7 @@ role_assignment=$(MSYS_NO_PATHCONV=1 az role assignment list \
   --query "[].roleDefinitionId" -o tsv)
 
 if [ -z "$role_assignment" ]; then
-    echo "User does not have the Azure AI User role. Assigning the role..."
+    echo "User does not have the Foundry User role. Assigning the role..."
     MSYS_NO_PATHCONV=1 az role assignment create \
       --assignee "$signed_user_id" \
       --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" \
@@ -208,13 +208,13 @@ if [ -z "$role_assignment" ]; then
       --output none
 
     if [ $? -eq 0 ]; then
-        echo "✅ Azure AI User role assigned successfully."
+        echo "✅ Foundry User role assigned successfully."
     else
-        echo "❌ Failed to assign Azure AI User role."
+        echo "❌ Failed to assign Foundry User role."
         exit 1
     fi
 else
-    echo "User already has the Azure AI User role."
+    echo "User already has the Foundry User role."
 fi
 
 

--- a/infra/scripts/fabric_scripts/run_fabric_items_scripts.sh
+++ b/infra/scripts/fabric_scripts/run_fabric_items_scripts.sh
@@ -212,7 +212,7 @@ fi
 
 # echo "Azure AI Foundry ID: $ai_foundry_resource_id"
 
-# echo "Assigning the Azure AI User role to the user..."
+# echo "Assigning the Foundry User role to the user..."
 # az role assignment create --assignee $signed_user_id --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" --scope $ai_foundry_resource_id
 
 # # Check if the role assignment command was successful

--- a/src/start.cmd
+++ b/src/start.cmd
@@ -378,25 +378,25 @@ echo [INFO] No Azure SQL Server configured, skipping admin role assignment.
 :done_sql
 
 REM ============================================================
-REM  Azure AI User role assignment (only when AI_FOUNDRY_RESOURCE_ID is set)
+REM  Foundry User role assignment (only when AI_FOUNDRY_RESOURCE_ID is set)
 REM ============================================================
 if not defined AI_FOUNDRY_RESOURCE_ID goto :skip_aiuser
 if "!AI_FOUNDRY_RESOURCE_ID!"=="" goto :skip_aiuser
 
 FOR /F "delims=" %%s IN ('az account show --query id -o tsv') DO set "subscription_id=%%s"
 
-echo Checking Azure AI User role assignment...
+echo Checking Foundry User role assignment...
 FOR /F "delims=" %%i IN ('az role assignment list --assignee %signed_user_id% --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" --scope "%AI_FOUNDRY_RESOURCE_ID%" --query "[0].id" -o tsv 2^>nul') DO set "aiUserRoleExists=%%i"
 if defined aiUserRoleExists (
-    echo User already has the Azure AI User role.
+    echo User already has the Foundry User role.
 ) else (
-    echo Assigning Azure AI User role to AI Foundry account...
+    echo Assigning Foundry User role to AI Foundry account...
     call az role assignment create ^
         --assignee %signed_user_id% ^
         --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" ^
         --scope "%AI_FOUNDRY_RESOURCE_ID%" ^
         --output none
-    echo Azure AI User role assigned successfully.
+    echo Foundry User role assigned successfully.
 )
 goto :done_aiuser
 

--- a/src/start.sh
+++ b/src/start.sh
@@ -372,25 +372,25 @@ else
 fi
 
 # ============================================================
-#  Azure AI User role assignment (only when AI_FOUNDRY_RESOURCE_ID is set)
+#  Foundry User role assignment (only when AI_FOUNDRY_RESOURCE_ID is set)
 # ============================================================
 if [ -n "$AI_FOUNDRY_RESOURCE_ID" ]; then
-    echo "Checking Azure AI User role assignment..."
+    echo "Checking Foundry User role assignment..."
     aiUserRoleExists=$(az role assignment list \
         --assignee "$signed_user_id" \
         --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" \
         --scope "$AI_FOUNDRY_RESOURCE_ID" \
         --query "[0].id" -o tsv 2>/dev/null)
     if [ -n "$aiUserRoleExists" ]; then
-        echo "User already has the Azure AI User role."
+        echo "User already has the Foundry User role."
     else
-        echo "Assigning Azure AI User role to AI Foundry account..."
+        echo "Assigning Foundry User role to AI Foundry account..."
         az role assignment create \
             --assignee "$signed_user_id" \
             --role "53ca6127-db72-4b80-b1b0-d745d6d5456d" \
             --scope "$AI_FOUNDRY_RESOURCE_ID" \
             --output none
-        echo "Azure AI User role assigned successfully."
+        echo "Foundry User role assigned successfully."
     fi
 else
     echo "[INFO] No AI Foundry resource configured, skipping AI User role assignment."


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request updates the naming of an Azure role from "Azure AI User" to "Foundry User" throughout the codebase and documentation to align with current Azure terminology. Additionally, it updates infrastructure files generated by Bicep to a newer version, which affects template hashes and formatting.

**Role Naming Updates:**

* Updated all user-facing strings, comments, and documentation to reference the "Foundry User" role instead of "Azure AI User" in shell scripts, Bicep templates, and markdown guides. This includes assignment commands, status messages, and inline comments. [[1]](diffhunk://#diff-2ad8cf71fb862ed25e6781c4dbb8a1950b48fa337a058ba02a3573a19f4224ccL281-R284) [[2]](diffhunk://#diff-2ad8cf71fb862ed25e6781c4dbb8a1950b48fa337a058ba02a3573a19f4224ccL293-R296) [[3]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L289-R289) [[4]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L520-R520) [[5]](diffhunk://#diff-bfb65ac3d115f97bd3545f894d6f3e002c9b2b72071df87a08ae4af8d8cbe517L195-R217) [[6]](diffhunk://#diff-99209a4d125678f1546b9d6c8cfbb93d74792b208067b924fbb451d893883d26L215-R215)

**Infrastructure and Template Updates:**

* Upgraded the Bicep compiler version used for generating `infra/main.json` from 0.42.1 to 0.43.8, resulting in updated `_generator` metadata and new template hashes throughout the file. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L7-R8) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L533-R534) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L686-R687) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1574-R1575) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1706-R1707) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1832-R1833) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2094-R2095) [[8]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2472-R2473) [[9]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2648-R2649) [[10]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2803-R2804) [[11]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2970-R2971) [[12]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3125-R3126) [[13]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3259-R3260) [[14]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3338-R3339) [[15]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3479-R3480) [[16]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3829-R3830) [[17]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3903-R3903) [[18]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3941-R3942) [[19]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4075-R4076) [[20]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4154-R4155) [[21]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4295-R4296) [[22]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4605-R4606) [[23]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4690-R4691) [[24]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4824-R4825)

* Minor formatting changes in JSON strings for `reactAppLayoutConfig` to use Unix line endings instead of Windows line endings. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3058-R3058) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3903-R3903)

These changes ensure consistency and up-to-date terminology across the project, and keep the infrastructure code aligned with the latest Bicep tooling.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

