### PR TITLE
chore: downmerge from main to dev

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -2,13 +2,6 @@ name: Azure Dev Deploy
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'infra/**'
-      - 'azure.yaml'
-      - '.github/workflows/azure-dev.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Purpose
This pull request makes a small change to the GitHub Actions workflow configuration for Azure deployments. The change removes the automatic triggering of the workflow on pushes to the `main` branch affecting infrastructure-related files, so the workflow can now only be triggered manually.

* Removed the `push` trigger for the Azure Dev Deploy workflow, restricting execution to manual dispatch only in `.github/workflows/azure-dev.yml`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.