### PR TITLE
refactor: Updated log messages and function names

### DIFF
--- a/scripts/generate_env_from_azure.py
+++ b/scripts/generate_env_from_azure.py
@@ -369,7 +369,7 @@ def generate_env_from_app_service(resource_group: str, app_name: str) -> str | N
         "API_UID", "API_PID", "MID_DISPLAY_NAME",
         # App Service
         "WEB_APP_URL", "API_APP_NAME",
-        # Workshop
+        # Deployment
         "USE_CASE", "BACKEND_RUNTIME_STACK",
     ]
     

--- a/src/api/python/chat.py
+++ b/src/api/python/chat.py
@@ -164,9 +164,9 @@ def _extract_mcp_from_raw(raw_repr, mcp_docs: dict):
                 _parse_mcp_docs(item_output, mcp_docs)
 
 
-async def stream_openai_text_workshop(conversation_id: str, query: str, user_id: str = "", user_assertion: str = None):
+async def stream_openai_text(conversation_id: str, query: str, user_id: str = "", user_assertion: str = None):
     """
-    Async generator yielding ``(role, content)`` tuples (workshop mode).
+    Async generator yielding ``(role, content)`` tuples.
 
     Uses FoundryAgent with agent_framework to handle function calls (SQL)
     and search tools automatically.  Fabric SQL is used when AZURE_ENV_ONLY
@@ -200,10 +200,10 @@ async def stream_openai_text_workshop(conversation_id: str, query: str, user_id:
                 from history_sql import SqlQueryTool, get_azure_sql_connection, get_fabric_db_connection
 
                 if AZURE_ENV_ONLY:
-                    logger.info("Workshop mode: Using Azure SQL Database")
+                    logger.info("Using Azure SQL Database")
                     db_connection = await get_azure_sql_connection()
                 else:
-                    logger.info("Workshop mode: Using Fabric Lakehouse SQL")
+                    logger.info("Using Fabric Lakehouse SQL")
                     db_connection = await get_fabric_db_connection()
 
                 if not db_connection:
@@ -211,7 +211,7 @@ async def stream_openai_text_workshop(conversation_id: str, query: str, user_id:
 
                 custom_tool = SqlQueryTool(pyodbc_conn=db_connection) if db_connection else None
             else:
-                logger.info("Workshop mode: Using Fabric Data Agent (MCP) - skipping local SQL tool")
+                logger.info("Using Fabric Data Agent (MCP) - skipping local SQL tool")
 
             # Create agent with tools
             agent_name = os.getenv("AGENT_NAME_CHAT")
@@ -328,7 +328,7 @@ async def stream_openai_text_workshop(conversation_id: str, query: str, user_id:
 
     except Exception as e:
         complete_response = str(e)
-        logger.exception("Error in stream_openai_text_workshop: %s", e)
+        logger.exception("Error in stream_openai_text: %s", e)
         cache = get_thread_cache()
         conv_id = cache.pop(conversation_id, None)
         if conv_id is not None:
@@ -356,7 +356,7 @@ async def stream_chat_request(conversation_id, query, user_id: str = "", user_as
     async def generate():
         try:
             assistant_content = ""
-            async for role, content in stream_openai_text_workshop(conversation_id, query, user_id=user_id, user_assertion=user_assertion):
+            async for role, content in stream_openai_text(conversation_id, query, user_id=user_id, user_assertion=user_assertion):
                 if not content:
                     continue
                 if role == "assistant":

--- a/src/test/api/python/test_chat.py
+++ b/src/test/api/python/test_chat.py
@@ -317,9 +317,9 @@ class TestStreamOpenAIText:
             assert "cannot answer" in results[0].lower()
 
     @pytest.mark.asyncio
-    async def test_workshop_passes_conversation_id_in_options(self):
-        """Verify workshop mode agent.run is called with options={'conversation_id': conv_id}."""
-        from chat import stream_openai_text_workshop
+    async def test_passes_conversation_id_in_options(self):
+        """Verify agent.run is called with options={'conversation_id': conv_id}."""
+        from chat import stream_openai_text
 
         mock_chunk = Mock()
         mock_chunk.text = "Hello"
@@ -359,7 +359,7 @@ class TestStreamOpenAIText:
             mock_cache.return_value = {}
 
             results = []
-            async for item in stream_openai_text_workshop("test_conv", "hello", "user1"):
+            async for item in stream_openai_text("test_conv", "hello", "user1"):
                 results.append(item)
 
             # Verify agent.run was called with options containing conversation_id
@@ -506,8 +506,7 @@ class TestAdditionalCoverage:
             yield ("assistant", "Hello")
             yield ("assistant", " World")
 
-        with patch('chat.stream_openai_text', side_effect=mock_stream), \
-             patch('chat.stream_openai_text_workshop', side_effect=mock_stream):
+        with patch('chat.stream_openai_text', side_effect=mock_stream):
             results = []
             generator = await stream_chat_request("123", "test")
             async for chunk in generator:
@@ -1009,7 +1008,7 @@ class TestStreamChatRequestDelta:
             yield ("assistant", "Hello world")
             yield ("tool", '[{"url":"u","source":"s","id":"i"}]')
 
-        with patch('chat.stream_openai_text_workshop', side_effect=mock_gen):
+        with patch('chat.stream_openai_text', side_effect=mock_gen):
             gen = await stream_chat_request("conv1", "test query")
             chunks = []
             async for chunk in gen:


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* 
This pull request primarily refactors the chat streaming API by renaming and generalizing the `stream_openai_text_workshop` function to `stream_openai_text` throughout the codebase. This change removes references to "workshop mode," making the code and logs more generic and applicable to broader use cases. Associated tests and log messages have also been updated to reflect this change.

**Refactoring and Generalization:**

* Renamed the `stream_openai_text_workshop` function to `stream_openai_text` in `chat.py`, and updated all references, including function calls and imports, to use the new name. This makes the function more broadly applicable and removes the "workshop" context. [[1]](diffhunk://#diff-484b9831a8601f576c8dae458b4255a7fad76176a5c15e2e34aedfcf0e5518a2L167-R169) [[2]](diffhunk://#diff-484b9831a8601f576c8dae458b4255a7fad76176a5c15e2e34aedfcf0e5518a2L359-R359) [[3]](diffhunk://#diff-795b60713395a272eea46a420eadd106adb4f9eb4de2622d1a5a7c712d67526bL320-R322) [[4]](diffhunk://#diff-795b60713395a272eea46a420eadd106adb4f9eb4de2622d1a5a7c712d67526bL362-R362) [[5]](diffhunk://#diff-795b60713395a272eea46a420eadd106adb4f9eb4de2622d1a5a7c712d67526bL509-R509) [[6]](diffhunk://#diff-795b60713395a272eea46a420eadd106adb4f9eb4de2622d1a5a7c712d67526bL1012-R1011)
* Updated logging messages in `chat.py` to remove "Workshop mode" references, making them more generic (e.g., "Using Azure SQL Database" instead of "Workshop mode: Using Azure SQL Database").
* Updated exception logging to use the new function name in log messages.

**Documentation and Naming:**

* Updated docstrings and comments to remove references to "workshop mode" and clarify that the function is now generic. [[1]](diffhunk://#diff-484b9831a8601f576c8dae458b4255a7fad76176a5c15e2e34aedfcf0e5518a2L167-R169) [[2]](diffhunk://#diff-795b60713395a272eea46a420eadd106adb4f9eb4de2622d1a5a7c712d67526bL320-R322)

**Other Minor Changes:**

* Changed a comment in `generate_env_from_azure.py` from "Workshop" to "Deployment" for clarity.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

