### PR TITLE
fix: private endpoint provisioning conflict  bicep changes CognitiveServices/accounts fail

### DIFF
--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -36,6 +36,9 @@ param existingLogAnalyticsWorkspaceId string = ''
 @description('The resource ID of an existing Azure AI Foundry project. If provided, the existing project will be used instead of creating a new one.')
 param azureExistingAIProjectResourceId string = ''
 
+@description('When using an existing AI project, set true only if you explicitly need this template to update the AI Services account identity/configuration.')
+param updateExistingAiResources bool = false
+
 @description('The principal ID of the user deploying the solution, used for role assignments.')
 param deployingUserPrincipalId string = ''
 
@@ -339,7 +342,7 @@ module assignFoundryRoleToMIExisting 'deploy_foundry_role_assignment.bicep' = if
     aiSkuName: existing_aiServicesModule.outputs.skuName
     customSubDomainName: existing_aiServicesModule.outputs.customSubDomainName
     publicNetworkAccess: existing_aiServicesModule.outputs.publicNetworkAccess
-    enableSystemAssignedIdentity: true
+    enableSystemAssignedIdentity: updateExistingAiResources
     defaultNetworkAction: existing_aiServicesModule.outputs.defaultNetworkAction
     vnetRules: existing_aiServicesModule.outputs.vnetRules
     ipRules: existing_aiServicesModule.outputs.ipRules
@@ -366,7 +369,7 @@ module existingOpenAiProject 'deploy_foundry_role_assignment.bicep' = if (!empty
     aiServicesName: existingAIServicesName
     aiProjectName: existingAIProjectName
     principalId: searchServiceEnableIdentity.outputs.principalId
-    enableSystemAssignedIdentity: true
+    enableSystemAssignedIdentity: updateExistingAiResources
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -16,6 +16,9 @@ param existingLogAnalyticsWorkspaceId string = ''
 @description('Use this parameter to use an existing AI project resource ID')
 param azureExistingAIProjectResourceId string = ''
 
+@description('When using an existing AI project, set true only if you explicitly need this template to update the AI Services account identity/configuration.')
+param updateExistingAiResources bool = false
+
 @description('Optional. created by user name')
 param createdBy string = !empty(deployer().?userPrincipalName ?? '') ? split(deployer().userPrincipalName, '@')[0] : !empty(deployer().?objectId ?? '') ? deployer().objectId : 'unknown-deployer'
 
@@ -202,6 +205,7 @@ module aifoundry 'deploy_ai_foundry.bicep' = {
     managedIdentityObjectId: managedIdentityModule.outputs.managedIdentityOutput.objectId
     existingLogAnalyticsWorkspaceId: existingLogAnalyticsWorkspaceId
     azureExistingAIProjectResourceId: azureExistingAIProjectResourceId
+    updateExistingAiResources: updateExistingAiResources
     deployingUserPrincipalId: deployingUserPrincipalId
     deployingUserPrincipalType: deployingUserPrincipalType
     isWorkshop: isWorkshop

--- a/infra/main.json
+++ b/infra/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.43.8.12551",
-      "templateHash": "14725722152258956764"
+      "version": "0.44.1.10279",
+      "templateHash": "9588874040311552259"
     }
   },
   "parameters": {
@@ -38,6 +38,13 @@
       "defaultValue": "",
       "metadata": {
         "description": "Use this parameter to use an existing AI project resource ID"
+      }
+    },
+    "updateExistingAiResources": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "When using an existing AI project, set true only if you explicitly need this template to update the AI Services account identity/configuration."
       }
     },
     "createdBy": {
@@ -530,8 +537,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "13536969934887418432"
+              "version": "0.44.1.10279",
+              "templateHash": "15135740503874659425"
             }
           },
           "parameters": {
@@ -664,6 +671,9 @@
           "azureExistingAIProjectResourceId": {
             "value": "[parameters('azureExistingAIProjectResourceId')]"
           },
+          "updateExistingAiResources": {
+            "value": "[parameters('updateExistingAiResources')]"
+          },
           "deployingUserPrincipalId": {
             "value": "[variables('deployingUserPrincipalId')]"
           },
@@ -683,8 +693,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "7328767993983191959"
+              "version": "0.44.1.10279",
+              "templateHash": "17811145908650686074"
             }
           },
           "parameters": {
@@ -756,6 +766,13 @@
               "defaultValue": "",
               "metadata": {
                 "description": "The resource ID of an existing Azure AI Foundry project. If provided, the existing project will be used instead of creating a new one."
+              }
+            },
+            "updateExistingAiResources": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "When using an existing AI project, set true only if you explicitly need this template to update the AI Services account identity/configuration."
               }
             },
             "deployingUserPrincipalId": {
@@ -1581,8 +1598,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "8325817338129258671"
+                      "version": "0.44.1.10279",
+                      "templateHash": "12735829290112286216"
                     }
                   },
                   "parameters": {
@@ -1713,8 +1730,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "5149350788597687463"
+                      "version": "0.44.1.10279",
+                      "templateHash": "8937056946304461146"
                     }
                   },
                   "parameters": {
@@ -1818,7 +1835,7 @@
                     "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('existingAIServiceSubscription'), variables('existingAIServiceResourceGroup')), 'Microsoft.Resources/deployments', 'existing_foundry_project'), '2025-04-01').outputs.publicNetworkAccess.value]"
                   },
                   "enableSystemAssignedIdentity": {
-                    "value": true
+                    "value": "[parameters('updateExistingAiResources')]"
                   },
                   "defaultNetworkAction": {
                     "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('existingAIServiceSubscription'), variables('existingAIServiceResourceGroup')), 'Microsoft.Resources/deployments', 'existing_foundry_project'), '2025-04-01').outputs.defaultNetworkAction.value]"
@@ -1839,8 +1856,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "3195854664465026554"
+                      "version": "0.44.1.10279",
+                      "templateHash": "15826640358165771980"
                     }
                   },
                   "parameters": {
@@ -2092,7 +2109,7 @@
                     "value": "[reference(resourceId('Microsoft.Resources/deployments', 'searchServiceIdentity'), '2025-04-01').outputs.principalId.value]"
                   },
                   "enableSystemAssignedIdentity": {
-                    "value": true
+                    "value": "[parameters('updateExistingAiResources')]"
                   }
                 },
                 "template": {
@@ -2101,8 +2118,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "3195854664465026554"
+                      "version": "0.44.1.10279",
+                      "templateHash": "15826640358165771980"
                     }
                   },
                   "parameters": {
@@ -2479,8 +2496,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "11610267304629320537"
+              "version": "0.44.1.10279",
+              "templateHash": "5735182887125385281"
             }
           },
           "parameters": {
@@ -2655,8 +2672,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "11421679036623536575"
+              "version": "0.44.1.10279",
+              "templateHash": "6318711679385475909"
             }
           },
           "parameters": {
@@ -2810,8 +2827,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "9298238518588007961"
+              "version": "0.44.1.10279",
+              "templateHash": "9617801952755363366"
             },
             "description": "Creates an Azure App Service plan."
           },
@@ -2977,8 +2994,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "7125338740685927774"
+              "version": "0.44.1.10279",
+              "templateHash": "10214454754470022340"
             }
           },
           "parameters": {
@@ -3132,8 +3149,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "6010975927430793235"
+                      "version": "0.44.1.10279",
+                      "templateHash": "17685429880412462148"
                     }
                   },
                   "parameters": {
@@ -3269,8 +3286,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.43.8.12551",
-                              "templateHash": "17534924770579664742"
+                              "version": "0.44.1.10279",
+                              "templateHash": "4793122329085283763"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -3348,8 +3365,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "8325817338129258671"
+                      "version": "0.44.1.10279",
+                      "templateHash": "12735829290112286216"
                     }
                   },
                   "parameters": {
@@ -3489,8 +3506,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "3195854664465026554"
+                      "version": "0.44.1.10279",
+                      "templateHash": "15826640358165771980"
                     }
                   },
                   "parameters": {
@@ -3839,8 +3856,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "1121802098664925876"
+              "version": "0.44.1.10279",
+              "templateHash": "16844022017701570123"
             }
           },
           "parameters": {
@@ -3951,8 +3968,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "6010975927430793235"
+                      "version": "0.44.1.10279",
+                      "templateHash": "17685429880412462148"
                     }
                   },
                   "parameters": {
@@ -4088,8 +4105,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.43.8.12551",
-                              "templateHash": "17534924770579664742"
+                              "version": "0.44.1.10279",
+                              "templateHash": "4793122329085283763"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },
@@ -4167,8 +4184,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "8325817338129258671"
+                      "version": "0.44.1.10279",
+                      "templateHash": "12735829290112286216"
                     }
                   },
                   "parameters": {
@@ -4308,8 +4325,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "3195854664465026554"
+                      "version": "0.44.1.10279",
+                      "templateHash": "15826640358165771980"
                     }
                   },
                   "parameters": {
@@ -4618,8 +4635,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.43.8.12551",
-              "templateHash": "1401984777047551263"
+              "version": "0.44.1.10279",
+              "templateHash": "16457609025578611145"
             }
           },
           "parameters": {
@@ -4703,8 +4720,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.43.8.12551",
-                      "templateHash": "6010975927430793235"
+                      "version": "0.44.1.10279",
+                      "templateHash": "17685429880412462148"
                     }
                   },
                   "parameters": {
@@ -4840,8 +4857,8 @@
                           "metadata": {
                             "_generator": {
                               "name": "bicep",
-                              "version": "0.43.8.12551",
-                              "templateHash": "17534924770579664742"
+                              "version": "0.44.1.10279",
+                              "templateHash": "4793122329085283763"
                             },
                             "description": "Updates app settings for an Azure App Service."
                           },

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -27,6 +27,9 @@ param existingLogAnalyticsWorkspaceId string = ''
 @description('Use this parameter to use an existing AI project resource ID')
 param azureExistingAIProjectResourceId string = ''
 
+@description('When using an existing AI project, set true only if you explicitly need this template to update the AI Services account identity/configuration.')
+param updateExistingAiResources bool = false
+
 @description('Optional. created by user name')
 param createdBy string = !empty(deployer().?userPrincipalName ?? '') ? split(deployer().userPrincipalName, '@')[0] : !empty(deployer().?objectId ?? '') ? deployer().objectId : 'unknown-deployer'
 
@@ -188,6 +191,7 @@ module aifoundry 'deploy_ai_foundry.bicep' = {
     managedIdentityObjectId: managedIdentityModule.outputs.managedIdentityOutput.objectId
     existingLogAnalyticsWorkspaceId: existingLogAnalyticsWorkspaceId
     azureExistingAIProjectResourceId: azureExistingAIProjectResourceId
+    updateExistingAiResources: updateExistingAiResources
     deployingUserPrincipalId: deployingUserPrincipalId
     deployingUserPrincipalType: deployingUserPrincipalType
     isWorkshop: isWorkshop


### PR DESCRIPTION
This pull request introduces a new `updateExistingAiResources` parameter to the infrastructure deployment templates, allowing users to control whether the deployment updates the identity or configuration of existing AI Services resources. The parameter is threaded through both the main and AI Foundry deployment templates, and its value is used to conditionally enable system-assigned identities for existing resources. Several related updates to the generated `main.json` template ensure the new parameter is supported and correctly propagated.

The most important changes are:

**Parameterization and Resource Update Control:**

* Added a new boolean parameter `updateExistingAiResources` to both `infra/main.bicep` and `infra/deploy_ai_foundry.bicep`, with a description clarifying its use for updating identities/configuration of existing AI projects. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R19-R21) [[2]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R39-R41)
* Updated module invocations and resource definitions to use the value of `updateExistingAiResources` instead of always enabling system-assigned identities for existing resources. [[1]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L342-R345) [[2]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L369-R372) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R208)

**Template Propagation and Consistency:**

* Updated the generated `infra/main.json` ARM template to include the new parameter, propagate its value to nested deployments, and use it for conditional logic where appropriate. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R43-R49) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R674-R676) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R771-R777) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1821-R1838) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2095-R2112)

**Template Generation Updates:**

* Updated Bicep template metadata and hashes throughout `infra/main.json` to reflect the new Bicep compiler version and changes in template structure. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L7-R8) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L533-R541) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L686-R697) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1584-R1602) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1716-R1734) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L1842-R1860) [[7]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2482-R2500) [[8]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2658-R2676) [[9]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2813-R2831) [[10]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L2980-R2998) [[11]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3135-R3153) [[12]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3272-R3290) [[13]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3351-R3369) [[14]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3492-R3510) [[15]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3842-R3860) [[16]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L3954-R3972) [[17]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4091-R4109) [[18]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4170-R4188) [[19]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4311-R4329) [[20]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4621-R4639) [[21]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L4706-R4724)## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

