### PR TITLE
docs: Add note for re-running scenario scripts with --clean flag

### DIFF
--- a/documents/DeploymentGuide.md
+++ b/documents/DeploymentGuide.md
@@ -303,6 +303,15 @@ Once you've opened the project in [Codespaces](#github-codespaces), [Dev Contain
     ```
 
     **Using a Scenario Pack** (pre-built datasets — no AI generation needed):
+    > **Note:** If you have already deployed with default scenario or any other scenario, run the command with the `--clean` flag appended at the end:
+    >
+    > ```shell
+    > # Retail scenario:
+    > python infra/scripts/post-provision/00_build_solution.py --scenario retail --clean
+    >
+    > # Insurance scenario:
+    > python infra/scripts/post-provision/00_build_solution.py --scenario insurance --clean
+    > ```
 
     ```shell
     # Retail scenario:
@@ -312,15 +321,6 @@ Once you've opened the project in [Codespaces](#github-codespaces), [Dev Contain
     python infra/scripts/post-provision/00_build_solution.py --scenario insurance
     ```
 
-    > **Note:** If these scenario scripts fail on the first attempt, re-run the command with the `--clean` flag appended at the end:
-    >
-    > ```shell
-    > # Retail scenario:
-    > python infra/scripts/post-provision/00_build_solution.py --scenario retail --clean
-    >
-    > # Insurance scenario:
-    > python infra/scripts/post-provision/00_build_solution.py --scenario insurance --clean
-    > ```
 
     > **Tip:** To reuse an existing Fabric workspace, run `azd env set FABRIC_WORKSPACE_ID <your-workspace-id>` before building.
 

--- a/documents/DeploymentGuide.md
+++ b/documents/DeploymentGuide.md
@@ -312,6 +312,16 @@ Once you've opened the project in [Codespaces](#github-codespaces), [Dev Contain
     python infra/scripts/post-provision/00_build_solution.py --scenario insurance
     ```
 
+    > **Note:** If these scenario scripts fail on the first attempt, re-run the command with the `--clean` flag appended at the end:
+    >
+    > ```shell
+    > # Retail scenario:
+    > python infra/scripts/post-provision/00_build_solution.py --scenario retail --clean
+    >
+    > # Insurance scenario:
+    > python infra/scripts/post-provision/00_build_solution.py --scenario insurance --clean
+    > ```
+
     > **Tip:** To reuse an existing Fabric workspace, run `azd env set FABRIC_WORKSPACE_ID <your-workspace-id>` before building.
 
     > **Note:** Scenario packs skip data generation (step 01) and document upload (step 05) automatically.


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Added note to append --clean flag in case of build scripts fails.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

