### PR TITLE
chore: Update GPT model references  to gpt-5.4-mini and adjust version to 2026-03-17 across documentation and scripts

### DIFF
--- a/documents/CustomizingAzdParameters.md
+++ b/documents/CustomizingAzdParameters.md
@@ -13,8 +13,8 @@ By default this template will use the environment name as the prefix to prevent 
 | `AZURE_ENV_NAME`                          | string  | `env_name`               | Sets the environment name prefix for all Azure resources (3-20 chars).     |
 | `AZURE_ENV_SECONDARY_LOCATION`            | string  | `eastus2`                | Specifies a secondary Azure region for databases.                          |
 | `AZURE_ENV_MODEL_DEPLOYMENT_TYPE`      | string  | `GlobalStandard`         | Defines the model deployment type (allowed: `Standard`, `GlobalStandard`). |
-| `AZURE_ENV_GPT_MODEL_NAME`           | string  | `gpt-4.1-mini`           | Specifies the GPT model name (e.g., `gpt-4.1-mini`).                      |
-| `AZURE_ENV_GPT_MODEL_VERSION`            | string  | `2025-04-14`             | Sets the GPT model version.                                                |
+| `AZURE_ENV_GPT_MODEL_NAME`           | string  | `gpt-5.4-mini`           | Specifies the GPT model name (e.g., `gpt-5.4-mini`).                      |
+| `AZURE_ENV_GPT_MODEL_VERSION`            | string  | `2026-03-17`             | Sets the GPT model version.                                                |
 | `AZURE_ENV_OPENAI_API_VERSION`            | string  | `2025-01-01-preview`     | Specifies the API version for Azure OpenAI.                                |
 | `AZURE_ENV_GPT_MODEL_CAPACITY`  | integer | `150`                    | Sets the GPT model capacity (minimum: 10).                                 |
 | `AZURE_ENV_IMAGE_TAG`                    | string  | `latest_workshop`        | Sets the container image tag.                                              |

--- a/documents/DeploymentGuide.md
+++ b/documents/DeploymentGuide.md
@@ -150,8 +150,8 @@ When you start the deployment, most parameters will have **default values**, but
 | **Backend Programming Language**                   | Programming language for the backend API: **python** or **dotnet**.                           | *(empty)*              |
 | **Use Case**                   | Use case: **Retail-sales-analysis** or **Insurance-improve-customer-meetings**.                           | *(empty)*              |
 | **Deployment Type**                         | Select from a drop-down list (allowed: `Standard`, `GlobalStandard`).                                     | GlobalStandard         |
-| **GPT Model**                               | Choose from **gpt-4, gpt-4o, gpt-4o-mini**.                                                               | gpt-4o-mini            |
-| **GPT Model Version**                       | The version of the selected GPT model.                                                                    | 2024-07-18             |
+| **GPT Model**                               | Choose from **gpt-4, gpt-4o, gpt-4o-mini**.                                                               | gpt-5.4-mini           |
+| **GPT Model Version**                       | The version of the selected GPT model.                                                                    | 2026-03-17             |
 | **OpenAI API Version**                      | The Azure OpenAI API version to use.                                                                      | 2025-01-01-preview     |
 | **GPT Model Deployment Capacity**           | Configure capacity for **GPT models** (in thousands).                                                     | 30k                    |
 | **Image Tag**                               | Docker image tag to deploy. Common values: `latest`, `dev`, `hotfix`.                  | latest       |
@@ -166,9 +166,9 @@ When you start the deployment, most parameters will have **default values**, but
 <details>
   <summary><b>[Optional] Quota Recommendations</b></summary>
 
-By default, the **Gpt-4o-mini model capacity** in deployment is set to **30k tokens**, so we recommend updating the following:
+By default, the **gpt-5.4-mini model capacity** in deployment is set to **30k tokens**, so we recommend updating the following:
 
-> **For Global Standard | GPT-4o-mini - increase the capacity to at least 150k tokens post-deployment for optimal performance.**
+> **For Global Standard | gpt-5.4-mini - increase the capacity to at least 150k tokens post-deployment for optimal performance.**
 
 Depending on your subscription quota and capacity, you can [adjust quota settings](AzureGPTQuotaSettings.md) to better meet your specific needs. You can also [adjust the deployment parameters](CustomizingAzdParameters.md) for additional optimization.
 

--- a/infra/deploy_ai_foundry.bicep
+++ b/infra/deploy_ai_foundry.bicep
@@ -10,7 +10,7 @@ param solutionLocation string
 @description('The deployment type for the GPT model (e.g., Standard, GlobalStandard).')
 param deploymentType string
 
-@description('The name of the GPT model to deploy (e.g., gpt-4o, gpt-4).')
+@description('The name of the GPT model to deploy (e.g., gpt-5.4-mini).')
 param gptModelName string
 
 @description('The version of the GPT model to deploy.')

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -50,10 +50,10 @@ param searchServiceLocation string = resourceGroup().location
 param deploymentType string = 'GlobalStandard'
 
 @description('Name of the GPT model to deploy:')
-param gptModelName string = 'gpt-5-mini'
+param gptModelName string = 'gpt-5.4-mini'
 
 @description('Version of the GPT model to deploy:')
-param gptModelVersion string = '2025-08-07'
+param gptModelVersion string = '2026-03-17'
 
 param azureOpenAIApiVersion string = '2025-01-01-preview'
 
@@ -142,7 +142,7 @@ var solutionSuffix = toLower(trim(replace(
   azd:{
     type: 'location'
     usageName: [
-      'OpenAI.GlobalStandard.gpt4.1-mini,20'
+      'OpenAI.GlobalStandard.gpt-5.4-mini,20'
       'OpenAI.GlobalStandard.text-embedding-3-small,80'
     ]
   }
@@ -415,7 +415,7 @@ output AZURE_COSMOSDB_CONVERSATIONS_CONTAINER string = isWorkshop ? 'conversatio
 @description('Cosmos DB database name for conversation history')
 output AZURE_COSMOSDB_DATABASE string = isWorkshop ? 'db_conversation_history' : ''
 
-@description('GPT model deployment name (e.g., gpt-4o-mini)')
+@description('GPT model deployment name (e.g., gpt-5.4-mini)')
 output AZURE_ENV_GPT_MODEL_NAME string = gptModelName
 
 @description('Azure OpenAI service endpoint URL')

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "14322627335104775868"
+      "templateHash": "13422484550730664644"
     }
   },
   "parameters": {
@@ -99,14 +99,14 @@
     },
     "gptModelName": {
       "type": "string",
-      "defaultValue": "gpt-5-mini",
+      "defaultValue": "gpt-5.4-mini",
       "metadata": {
         "description": "Name of the GPT model to deploy:"
       }
     },
     "gptModelVersion": {
       "type": "string",
-      "defaultValue": "2025-08-07",
+      "defaultValue": "2026-03-17",
       "metadata": {
         "description": "Version of the GPT model to deploy:"
       }
@@ -234,7 +234,7 @@
         "azd": {
           "type": "location",
           "usageName": [
-            "OpenAI.GlobalStandard.gpt4.1-mini,20",
+            "OpenAI.GlobalStandard.gpt-5.4-mini,20",
             "OpenAI.GlobalStandard.text-embedding-3-small,80"
           ]
         },
@@ -824,7 +824,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "10451455981184581021"
+              "templateHash": "2041035845133379254"
             }
           },
           "parameters": {
@@ -850,7 +850,7 @@
             "gptModelName": {
               "type": "string",
               "metadata": {
-                "description": "The name of the GPT model to deploy (e.g., gpt-4o, gpt-4)."
+                "description": "The name of the GPT model to deploy (e.g., gpt-5.4-mini)."
               }
             },
             "gptModelVersion": {
@@ -5175,7 +5175,7 @@
     "AZURE_ENV_GPT_MODEL_NAME": {
       "type": "string",
       "metadata": {
-        "description": "GPT model deployment name (e.g., gpt-4o-mini)"
+        "description": "GPT model deployment name (e.g., gpt-5.4-mini)"
       },
       "value": "[parameters('gptModelName')]"
     },

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -132,7 +132,7 @@ var solutionSuffix = toLower(trim(replace(
   azd: {
     type: 'location'
     usageName: [
-      'OpenAI.GlobalStandard.gpt4.1-mini,20'
+      'OpenAI.GlobalStandard.gpt-5.4-mini,20'
       'OpenAI.GlobalStandard.text-embedding-3-small,80'
     ]
   }

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -65,10 +65,10 @@ param searchServiceLocation string = resourceGroup().location
 param deploymentType string = 'GlobalStandard'
 
 @description('Name of the GPT model to deploy:')
-param gptModelName string = 'gpt-5-mini'
+param gptModelName string = 'gpt-5.4-mini'
 
 @description('Version of the GPT model to deploy:')
-param gptModelVersion string = '2025-08-07'
+param gptModelVersion string = '2026-03-17'
 
 param azureOpenAIApiVersion string = '2025-01-01-preview'
 
@@ -393,7 +393,7 @@ output AZURE_COSMOSDB_CONVERSATIONS_CONTAINER string = isWorkshop ? 'conversatio
 @description('Cosmos DB database name for conversation history')
 output AZURE_COSMOSDB_DATABASE string = isWorkshop ? 'db_conversation_history' : ''
 
-@description('GPT model deployment name (e.g., gpt-4o-mini)')
+@description('GPT model deployment name (e.g., gpt-5.4-mini)')
 output AZURE_ENV_GPT_MODEL_NAME string = gptModelName
 
 @description('Azure OpenAI service endpoint URL')

--- a/infra/main_custom.json
+++ b/infra/main_custom.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "10114190453070608008"
+      "templateHash": "10319810619476764090"
     }
   },
   "parameters": {
@@ -106,14 +106,14 @@
     },
     "gptModelName": {
       "type": "string",
-      "defaultValue": "gpt-5-mini",
+      "defaultValue": "gpt-5.4-mini",
       "metadata": {
         "description": "Name of the GPT model to deploy:"
       }
     },
     "gptModelVersion": {
       "type": "string",
-      "defaultValue": "2025-08-07",
+      "defaultValue": "2026-03-17",
       "metadata": {
         "description": "Version of the GPT model to deploy:"
       }
@@ -607,7 +607,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "8654133598391472726"
+              "templateHash": "12120005818918099664"
             }
           },
           "parameters": {
@@ -649,23 +649,16 @@
               "location": "[parameters('solutionLocation')]",
               "tags": "[if(empty(parameters('solutionName')), createObject(), createObject('app', parameters('solutionName'), 'location', parameters('solutionLocation')))]",
               "sku": {
-                "name": "Premium"
+                "name": "Standard"
               },
               "properties": {
                 "adminUserEnabled": false,
                 "anonymousPullEnabled": false,
                 "dataEndpointEnabled": false,
                 "networkRuleBypassOptions": "AzureServices",
-                "networkRuleSet": {
-                  "defaultAction": "Allow"
-                },
                 "policies": {
                   "quarantinePolicy": {
                     "status": "disabled"
-                  },
-                  "retentionPolicy": {
-                    "status": "enabled",
-                    "days": 7
                   },
                   "trustPolicy": {
                     "status": "disabled",
@@ -788,7 +781,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "10451455981184581021"
+              "templateHash": "2041035845133379254"
             }
           },
           "parameters": {
@@ -814,7 +807,7 @@
             "gptModelName": {
               "type": "string",
               "metadata": {
-                "description": "The name of the GPT model to deploy (e.g., gpt-4o, gpt-4)."
+                "description": "The name of the GPT model to deploy (e.g., gpt-5.4-mini)."
               }
             },
             "gptModelVersion": {
@@ -5183,7 +5176,7 @@
     "AZURE_ENV_GPT_MODEL_NAME": {
       "type": "string",
       "metadata": {
-        "description": "GPT model deployment name (e.g., gpt-4o-mini)"
+        "description": "GPT model deployment name (e.g., gpt-5.4-mini)"
       },
       "value": "[parameters('gptModelName')]"
     },

--- a/infra/main_custom.json
+++ b/infra/main_custom.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "10319810619476764090"
+      "templateHash": "11157244727593213437"
     }
   },
   "parameters": {
@@ -202,7 +202,7 @@
         "azd": {
           "type": "location",
           "usageName": [
-            "OpenAI.GlobalStandard.gpt4.1-mini,20",
+            "OpenAI.GlobalStandard.gpt-5.4-mini,20",
             "OpenAI.GlobalStandard.text-embedding-3-small,80"
           ]
         },

--- a/infra/scripts/agent_scripts/run_create_agents_scripts.sh
+++ b/infra/scripts/agent_scripts/run_create_agents_scripts.sh
@@ -14,7 +14,7 @@ echo ""
 # Parameter details:
 #   $1  projectEndpoint          - Azure AI Project endpoint URL (e.g., https://<ai-service>.services.ai.azure.com/api/projects/<project-name>)  | azd env: AZURE_AI_AGENT_ENDPOINT
 #   $2  solutionName             - Solution name used as a suffix for resource naming                                                             | azd env: SOLUTION_NAME
-#   $3  gptModelName             - GPT model deployment name (e.g., gpt-4o-mini)                                                                 | azd env: AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME
+#   $3  gptModelName             - GPT model deployment name (e.g., gpt-5.4-mini)                                                                 | azd env: AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME
 #   $4  aiFoundryResourceId      - Full Azure resource ID of the AI Foundry (starts with /subscriptions/...)                                     | azd env: AI_FOUNDRY_RESOURCE_ID
 #   $5  apiAppName               - Name of the backend API App Service                                                                           | azd env: API_APP_NAME
 #   $6  resourceGroup            - Azure resource group name                                                                                     | azd env: AZURE_RESOURCE_GROUP
@@ -99,7 +99,7 @@ fi
 
 if [ -z "$gptModelName" ]; then
     echo "❌ ERROR: 'gptModelName' is missing."
-    echo "   Expected: GPT model deployment name (e.g., gpt-4o-mini, gpt-4o, gpt-4)"
+    echo "   Expected: GPT model deployment name (e.g., gpt-5.4-mini, gpt-4o, gpt-4)"
     echo "   Source:   Pass as argument \$3 or set azd env variable AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME"
     validation_failed=true
 fi

--- a/infra/scripts/checkquota_agentic_application.sh
+++ b/infra/scripts/checkquota_agentic_application.sh
@@ -28,7 +28,7 @@ echo "✅ Azure subscription set successfully."
 
 # Define models and their minimum required capacities
 declare -A MIN_CAPACITY=(
-    ["OpenAI.GlobalStandard.gpt-4o-mini"]=$GPT_MIN_CAPACITY
+    ["OpenAI.GlobalStandard.gpt-5.4-mini"]=$GPT_MIN_CAPACITY
 )
 
 VALID_REGION=""

--- a/infra/scripts/quota_check_params.sh
+++ b/infra/scripts/quota_check_params.sh
@@ -47,7 +47,7 @@ log_verbose() {
 }
 
 # Default Models and Capacities (Comma-separated in "model:capacity" format)
-DEFAULT_MODEL_CAPACITY="gpt4.1-mini:20,text-embedding-3-small:80"
+DEFAULT_MODEL_CAPACITY="gpt-5.4-mini:20,text-embedding-3-small:80"
 
 # Convert the comma-separated string into an array
 IFS=',' read -r -a MODEL_CAPACITY_PAIRS <<< "$DEFAULT_MODEL_CAPACITY"

--- a/scripts/.env
+++ b/scripts/.env
@@ -38,7 +38,7 @@ FOUNDRY_AGENT_ID=
 # --- Azure AI Foundry (from azd or manual) ---
 # AZURE_AI_AGENT_ENDPOINT=https://your-ai-service.services.ai.azure.com/api/projects/your-project
 # AZURE_AI_ENDPOINT=https://your-ai-service.services.ai.azure.com
-# AZURE_CHAT_MODEL=gpt-4.1-mini
+# AZURE_CHAT_MODEL=gpt-5.4-mini
 # AZURE_EMBEDDING_MODEL=text-embedding-3-large
 
 # --- Azure AI Search (from azd or manual) ---

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -36,7 +36,7 @@ FOUNDRY_AGENT_ID=
 # --- Azure AI Foundry (from azd or manual) ---
 # AZURE_AI_AGENT_ENDPOINT=https://your-ai-service.services.ai.azure.com/api/projects/your-project
 # AZURE_AI_ENDPOINT=https://your-ai-service.services.ai.azure.com
-# AZURE_CHAT_MODEL=gpt-4.1-mini
+# AZURE_CHAT_MODEL=gpt-5.4-mini
 # AZURE_EMBEDDING_MODEL=text-embedding-3-large
 
 # --- Azure AI Search (from azd or manual) ---

--- a/scripts/01_generate_data.py
+++ b/scripts/01_generate_data.py
@@ -114,7 +114,7 @@ credential = DefaultAzureCredential()
 from azure.ai.projects import AIProjectClient
 project_client = AIProjectClient(endpoint=FOUNDRY_ENDPOINT, credential=credential)
 client = project_client.get_openai_client()
-model = os.getenv("AZURE_CHAT_MODEL") or os.getenv("AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME", "gpt-4.1-mini")
+model = os.getenv("AZURE_CHAT_MODEL") or os.getenv("AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME", "gpt-5.4-mini")
 
 print("[OK] AI client initialized")
 

--- a/scripts/06_create_agent.py
+++ b/scripts/06_create_agent.py
@@ -78,7 +78,7 @@ from azure.ai.projects.models import (
 
 # Azure services - from azd environment
 ENDPOINT = os.getenv("AZURE_AI_AGENT_ENDPOINT")
-MODEL = os.getenv("AZURE_CHAT_MODEL") or os.getenv("AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME", "gpt-4.1-mini")
+MODEL = os.getenv("AZURE_CHAT_MODEL") or os.getenv("AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME", "gpt-5.4-mini")
 
 # Search mode
 USE_KNOWLEDGE_BASE = args.use_knowledge_base or True


### PR DESCRIPTION
## Purpose
This pull request updates the default GPT model used throughout the project from `gpt-4.1-mini` / `gpt-5-mini` to the newer `gpt-5.4-mini`, along with updating the default model version and related documentation. The changes ensure that all deployment templates, scripts, and documentation reference the new model and version, providing consistency and clarity for future deployments.

**Key changes include:**

**Model and Version Updates:**

* Changed the default GPT model to `gpt-5.4-mini` and the default version to `2026-03-17` in all infrastructure templates (`main.bicep`, `main_custom.bicep`, `main.json`, `main_custom.json`) and their outputs. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L53-R56) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L418-R418) [[3]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L68-R71) [[4]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L396-R396) [[5]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L102-R109) [[6]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L5178-R5178) [[7]](diffhunk://#diff-64cae76091e38fed83d0e7fe867633c6daed603cf8fba2c2386194f4bddf880eL109-R116) [[8]](diffhunk://#diff-64cae76091e38fed83d0e7fe867633c6daed603cf8fba2c2386194f4bddf880eL5186-R5179)
* Updated the example and default model names/versions in deployment parameter documentation and environment files. [[1]](diffhunk://#diff-2e319e20f66e2cd84d3764f457565dbc3fe39c15edc9d7c05801ff16c423598aL16-R17) [[2]](diffhunk://#diff-2afa876cbd4555ebfa7f423b650916642673e68d9d91b430ba3c72539e127ae5L153-R154) [[3]](diffhunk://#diff-2afa876cbd4555ebfa7f423b650916642673e68d9d91b430ba3c72539e127ae5L169-R171) [[4]](diffhunk://#diff-dbb050eb4b38289819f82d666083e0c53a59ff7adac08295392403550315548fL41-R41) [[5]](diffhunk://#diff-2443c102045eaf6707b56e0e9dd98c75fbe149c324bb67e7e6361f4d63959023L39-R39)

**Infrastructure and Template Consistency:**

* Updated all model references, descriptions, and usage examples in Bicep and JSON templates to use `gpt-5.4-mini`. [[1]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L13-R13) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L853-R853) [[3]](diffhunk://#diff-64cae76091e38fed83d0e7fe867633c6daed603cf8fba2c2386194f4bddf880eL817-R810)
* Adjusted the `azd` usage name and quota recommendations to reflect the new model. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L145-R145) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L237-R237) [[3]](diffhunk://#diff-2afa876cbd4555ebfa7f423b650916642673e68d9d91b430ba3c72539e127ae5L169-R171)

**Script Updates:**

* Changed default model references in Python scripts to use `gpt-5.4-mini`. [[1]](diffhunk://#diff-7c3a62ae664251d06b460e05f58d2c5bc0cb596abafa90b904d36871c132e144L117-R117) [[2]](diffhunk://#diff-7eb027ec64c2cfda9311253e6532e5984d51edf44fdb0b2ee2555f1443c94ebcL81-R81)

**Infrastructure Minor Adjustments:**

* Updated template hashes and some resource settings in generated JSON files to reflect the new configuration. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L8-R8) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L827-R827) [[3]](diffhunk://#diff-64cae76091e38fed83d0e7fe867633c6daed603cf8fba2c2386194f4bddf880eL8-R8) [[4]](diffhunk://#diff-64cae76091e38fed83d0e7fe867633c6daed603cf8fba2c2386194f4bddf880eL610-R610) [[5]](diffhunk://#diff-64cae76091e38fed83d0e7fe867633c6daed603cf8fba2c2386194f4bddf880eL791-R784)
* Modified container registry resource SKU from `Premium` to `Standard` and removed unused policy settings in `main_custom.json`.

These changes ensure the project is ready to use the latest GPT model by default, with all references, documentation, and infrastructure templates kept in sync.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.