### PR TITLE
feat: Implement dedicated ACR per deployment with managed identity auth

### DIFF
--- a/documents/CustomizingAzdParameters.md
+++ b/documents/CustomizingAzdParameters.md
@@ -17,8 +17,8 @@ By default this template will use the environment name as the prefix to prevent 
 | `BACKEND_RUNTIME_STACK`                   | string  | `python`                 | Backend language (allowed: `python`, `dotnet`).                            |
 | `DEPLOYMENT_FLAVOR`                       | string  | `bicep`                  | Deployment flavor (allowed: `bicep`, `avm`, `avm-waf`).                    |
 | `AZURE_ENV_MODEL_DEPLOYMENT_TYPE`         | string  | `GlobalStandard`         | Defines the model deployment type (allowed: `Standard`, `GlobalStandard`). |
-| `AZURE_ENV_GPT_MODEL_NAME`               | string  | `gpt-4.1-mini`           | Specifies the GPT model name (e.g., `gpt-4.1-mini`).                      |
-| `AZURE_ENV_GPT_MODEL_VERSION`            | string  | `2025-04-14`             | Sets the GPT model version.                                                |
+| `AZURE_ENV_GPT_MODEL_NAME`               | string  | `gpt-5.4-mini`           | Specifies the GPT model name (e.g., `gpt-5.4-mini`).                      |
+| `AZURE_ENV_GPT_MODEL_VERSION`            | string  | `2026-03-17`             | Sets the GPT model version.                                                |
 | `AZURE_ENV_OPENAI_API_VERSION`            | string  | `2025-01-01-preview`     | Specifies the API version for Azure OpenAI.                                |
 | `AZURE_ENV_GPT_MODEL_CAPACITY`            | integer | `150`                    | Sets the GPT model capacity (minimum: 10).                                 |
 | `AZURE_ENV_EMBEDDING_DEPLOYMENT_CAPACITY` | integer | `80`                     | Sets the embedding model deployment capacity (minimum: 10).                |

--- a/documents/DeploymentGuide.md
+++ b/documents/DeploymentGuide.md
@@ -184,8 +184,8 @@ When you start the deployment, most parameters will have **default values**, but
 | **Environment Name**                        | A **3–20 character alphanumeric value** used to generate a unique ID to prefix the resources.             | env\_name              |
 | **Backend Programming Language**            | Programming language for the backend API: **python** or **dotnet**.                                       | python                 |
 | **Deployment Type**                         | Select from a drop-down list (allowed: `Standard`, `GlobalStandard`).                                     | GlobalStandard         |
-| **GPT Model**                               | Name of the GPT model to deploy (e.g., `gpt-4.1-mini`).                                                  | gpt-4.1-mini           |
-| **GPT Model Version**                       | The version of the selected GPT model.                                                                    | 2025-04-14             |
+| **GPT Model**                               | Name of the GPT model to deploy (e.g., `gpt-5.4-mini`).                                                  | gpt-5.4-mini           |
+| **GPT Model Version**                       | The version of the selected GPT model.                                                                    | 2026-03-17             |
 | **OpenAI API Version**                      | The Azure OpenAI API version to use.                                                                      | 2025-01-01-preview     |
 | **GPT Model Deployment Capacity**           | Configure capacity for **GPT models** (in thousands).                                                     | 150                    |
 | **Image Tag**                               | Docker image tag to deploy. Common values: `latest_v2`, `dev`, `hotfix`.                                  | latest\_v2             |
@@ -200,7 +200,7 @@ When you start the deployment, most parameters will have **default values**, but
 <details>
   <summary><b>[Optional] Quota Recommendations</b></summary>
 
-By default, the **gpt-4.1-mini model capacity** in deployment is set to **150 TPM (thousands)**, which is the recommended minimum for optimal performance.
+By default, the **gpt-5.4-mini model capacity** in deployment is set to **150 TPM (thousands)**, which is the recommended minimum for optimal performance.
 
 Depending on your subscription quota and capacity, you can [adjust quota settings](AzureGPTQuotaSettings.md) to better meet your specific needs. You can also [adjust the deployment parameters](CustomizingAzdParameters.md) for additional optimization.
 

--- a/infra/avm/main.bicep
+++ b/infra/avm/main.bicep
@@ -984,6 +984,9 @@ module frontend_docker './modules/compute/app-service.bicep' = {
     acrUseManagedIdentityCreds: true
     virtualNetworkSubnetId: enablePrivateNetworking ? virtualNetwork!.outputs.webserverfarmSubnetResourceId : ''
     publicNetworkAccess: 'Enabled'
+    vnetRouteAllEnabled: enablePrivateNetworking ? true : false
+    imagePullTraffic: enablePrivateNetworking ? true : false
+    contentShareTraffic: enablePrivateNetworking ? true : false
     diagnosticSettings: monitoringDiagnosticSettings
     appSettings: {
       APP_API_BASE_URL: enablePrivateNetworking ? '' : apiBaseUrl

--- a/infra/avm/main.bicep
+++ b/infra/avm/main.bicep
@@ -79,7 +79,7 @@ param vmSize string = 'Standard_D2s_v5'
   azd: {
     type: 'location'
     usageName: [
-      'OpenAI.GlobalStandard.gpt4.1-mini,100'
+      'OpenAI.GlobalStandard.gpt-5.4-mini,100'
       'OpenAI.GlobalStandard.text-embedding-3-small,80'
     ]
   }
@@ -92,10 +92,10 @@ param azureAiServiceLocation string
 param deploymentType string = 'GlobalStandard'
 
 @description('Optional. Name of the GPT model to deploy.')
-param gptModelName string = 'gpt-4.1-mini'
+param gptModelName string = 'gpt-5.4-mini'
 
 @description('Optional. Version of the GPT model to deploy.')
-param gptModelVersion string = '2025-04-14'
+param gptModelVersion string = '2026-03-17'
 
 @minValue(10)
 @description('Optional. Capacity of the GPT deployment (TPM in thousands).')

--- a/infra/avm/main.bicep
+++ b/infra/avm/main.bicep
@@ -122,8 +122,8 @@ param azureAiAgentApiVersion string = '2025-05-01'
 @description('Optional. Docker image tag for app deployments.')
 param imageTag string = 'latest_v2'
 
-@description('Optional. Name of the Azure Container Registry.')
-param containerRegistryName string = 'dataagentscontainerreg'
+@description('Optional. Name of the Azure Container Registry. Empty derives a per-deployment name (cr<suffix>).')
+param containerRegistryName string = ''
 
 @allowed(['python', 'dotnet'])
 @description('Optional. Backend runtime stack.')
@@ -205,6 +205,14 @@ param appTitleSecondary string = '| Unified Data Analysis Agents'
 // ============================================================================
 
 var solutionSuffix = toLower(trim(replace(replace(replace(replace(replace(replace('${solutionName}${solutionUniqueText}', '-', ''), '_', ''), '.', ''), '/', ''), ' ', ''), '*', '')))
+
+// Container Registry: per-deployment ACR name (registry names: alphanumeric, 5-50 chars)
+var containerRegistryResourceName = !empty(containerRegistryName) ? containerRegistryName : take('cr${solutionSuffix}', 50)
+
+// Public placeholder image used at provision time. App Services start on this
+// image; the separate post-deployment script (infra/scripts/build/build-and-push-acr.*)
+// builds the real images into the dedicated ACR and repoints the apps.
+var placeholderContainerImage = 'DOCKER|mcr.microsoft.com/azuredocs/aci-helloworld:latest'
 var deployerInfo = deployer()
 var deployingUserPrincipalId = deployerInfo.objectId
 var createdBy = contains(deployerInfo, 'userPrincipalName') ? split(deployerInfo.userPrincipalName, '@')[0] : deployerInfo.objectId
@@ -273,6 +281,7 @@ var privateDnsZones = [
   #disable-next-line no-hardcoded-env-urls
   'privatelink.database.windows.net'
   'privatelink.azurewebsites.net'
+  'privatelink.azurecr.io'
 ]
 var dnsZoneIndex = {
   cognitiveServices: 0
@@ -283,6 +292,7 @@ var dnsZoneIndex = {
   search: 5
   sqlServer: 6
   webApp : 7
+  containerRegistry: 8
 }
 
 // Resource naming (parameterized — no abbreviations.json dependency)
@@ -784,6 +794,32 @@ module cosmosDBModule './modules/data/cosmos-db-nosql.bicep' = {
 }
 
 // ============================================================================
+// Module: Container Registry (dedicated per-deployment ACR)
+// ============================================================================
+
+module containerRegistry './modules/compute/container-registry.bicep' = {
+  name: take('module.container-registry.${solutionName}', 64)
+  params: {
+    solutionName: solutionSuffix
+    name: containerRegistryResourceName
+    location: location
+    tags: tags
+    enableTelemetry: enableTelemetry
+    // Premium is required for private endpoints; Standard otherwise.
+    sku: enablePrivateNetworking ? 'Premium' : 'Standard'
+    publicNetworkAccess: enablePrivateNetworking ? 'Disabled' : 'Enabled'
+    networkRuleSetDefaultAction: enablePrivateNetworking ? 'Deny' : 'Allow'
+    // Export policy must be enabled only when public access is enabled.
+    exportPolicyStatus: enablePrivateNetworking ? 'disabled' : 'enabled'
+    enablePrivateNetworking: enablePrivateNetworking
+    privateEndpointSubnetId: enablePrivateNetworking ? virtualNetwork!.outputs.backendSubnetResourceId : ''
+    privateDnsZoneResourceIds: enablePrivateNetworking ? [
+      privateDnsZoneDeployments[dnsZoneIndex.containerRegistry]!.outputs.resourceId
+    ] : []
+  }
+}
+
+// ============================================================================
 // Module: Compute
 // ============================================================================
 
@@ -812,7 +848,8 @@ module backend_docker './modules/compute/app-service.bicep' = if (backendRuntime
     tags: tags
     enableTelemetry: enableTelemetry
     serverFarmResourceId: hostingplan!.outputs.resourceId
-    linuxFxVersion: 'DOCKER|${containerRegistryName}.azurecr.io/da-api:${imageTag}'
+    linuxFxVersion: placeholderContainerImage
+    acrUseManagedIdentityCreds: true
     virtualNetworkSubnetId: enablePrivateNetworking ? virtualNetwork!.outputs.webserverfarmSubnetResourceId : ''
     publicNetworkAccess: enablePrivateNetworking ? 'Disabled' : 'Enabled'
     vnetRouteAllEnabled: enablePrivateNetworking ? true : false
@@ -878,7 +915,8 @@ module backend_csapi_docker './modules/compute/app-service.bicep' = if (backendR
     tags: tags
     enableTelemetry: enableTelemetry
     serverFarmResourceId: hostingplan!.outputs.resourceId
-    linuxFxVersion: 'DOCKER|${containerRegistryName}.azurecr.io/da-api-dotnet:${imageTag}'
+    linuxFxVersion: placeholderContainerImage
+    acrUseManagedIdentityCreds: true
     virtualNetworkSubnetId: enablePrivateNetworking ? virtualNetwork!.outputs.webserverfarmSubnetResourceId : ''
     publicNetworkAccess: enablePrivateNetworking ? 'Disabled' : 'Enabled'
     vnetRouteAllEnabled: enablePrivateNetworking ? true : false
@@ -942,7 +980,8 @@ module frontend_docker './modules/compute/app-service.bicep' = {
     tags: tags
     enableTelemetry: enableTelemetry
     serverFarmResourceId: hostingplan!.outputs.resourceId
-    linuxFxVersion: 'DOCKER|${containerRegistryName}.azurecr.io/da-app:${imageTag}'
+    linuxFxVersion: placeholderContainerImage
+    acrUseManagedIdentityCreds: true
     virtualNetworkSubnetId: enablePrivateNetworking ? virtualNetwork!.outputs.webserverfarmSubnetResourceId : ''
     publicNetworkAccess: 'Enabled'
     diagnosticSettings: monitoringDiagnosticSettings
@@ -971,6 +1010,8 @@ module role_assignments './modules/identity/role-assignments.bicep' = {
     storageAccountResourceId: storage_account.outputs.resourceId
     cosmosDbAccountName: cosmosDBModule.outputs.name
     backendAppServicePrincipalId: (backendRuntimeStack == 'python' ? backend_docker!.outputs.identityPrincipalId : backend_csapi_docker!.outputs.identityPrincipalId)
+    frontendAppServicePrincipalId: frontend_docker.outputs.identityPrincipalId
+    containerRegistryResourceId: containerRegistry.outputs.resourceId
     aiFoundryResourceId: aiFoundryResourceId
     useExistingAIProject: useExistingAIProject
     existingFoundryProjectResourceId: existingFoundryProjectResourceId
@@ -989,6 +1030,15 @@ output RESOURCE_GROUP_NAME string = resourceGroup().name
 
 @description('WAF deployment type.')
 output DEPLOYMENT_TYPE string = enablePrivateNetworking ? 'WAF' : 'Non-WAF'
+
+@description('Name of the dedicated Azure Container Registry.')
+output AZURE_ENV_CONTAINER_REGISTRY_NAME string = containerRegistry.outputs.name
+
+@description('Login server of the dedicated Azure Container Registry.')
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.outputs.loginServer
+
+@description('Docker image tag used for app deployments.')
+output AZURE_ENV_IMAGE_TAG string = imageTag
 
 @description('Cosmos DB account name.')
 output AZURE_COSMOSDB_ACCOUNT string = cosmosDBModule.outputs.name

--- a/infra/avm/main.json
+++ b/infra/avm/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "2782862649368459379"
+      "templateHash": "15406414339800399151"
     }
   },
   "parameters": {
@@ -114,7 +114,7 @@
         "azd": {
           "type": "location",
           "usageName": [
-            "OpenAI.GlobalStandard.gpt4.1-mini,100",
+            "OpenAI.GlobalStandard.gpt-5.4-mini,100",
             "OpenAI.GlobalStandard.text-embedding-3-small,80"
           ]
         },
@@ -134,14 +134,14 @@
     },
     "gptModelName": {
       "type": "string",
-      "defaultValue": "gpt-4.1-mini",
+      "defaultValue": "gpt-5.4-mini",
       "metadata": {
         "description": "Optional. Name of the GPT model to deploy."
       }
     },
     "gptModelVersion": {
       "type": "string",
-      "defaultValue": "2025-04-14",
+      "defaultValue": "2026-03-17",
       "metadata": {
         "description": "Optional. Version of the GPT model to deploy."
       }

--- a/infra/avm/main.json
+++ b/infra/avm/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "15406414339800399151"
+      "templateHash": "14683443711102617663"
     }
   },
   "parameters": {
@@ -45790,7 +45790,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "1223988259594936060"
+              "templateHash": "11760905568301824383"
             }
           },
           "parameters": {
@@ -45855,6 +45855,17 @@
               "defaultValue": "enabled",
               "metadata": {
                 "description": "Export policy status. Must be \"enabled\" when publicNetworkAccess is \"Enabled\"."
+              }
+            },
+            "azureADAuthenticationAsArmPolicyStatus": {
+              "type": "string",
+              "defaultValue": "enabled",
+              "allowedValues": [
+                "enabled",
+                "disabled"
+              ],
+              "metadata": {
+                "description": "Enable the ARM-audience AAD token policy. Must be \"enabled\" for App Service managed-identity image pulls to work (the AVM module defaults this to \"disabled\", which causes ACR token retrieval to fail with 401)."
               }
             },
             "acrPullPrincipalIds": {
@@ -46000,6 +46011,9 @@
                   },
                   "exportPolicyStatus": {
                     "value": "[parameters('exportPolicyStatus')]"
+                  },
+                  "azureADAuthenticationAsArmPolicyStatus": {
+                    "value": "[parameters('azureADAuthenticationAsArmPolicyStatus')]"
                   },
                   "roleAssignments": "[if(not(empty(variables('roleAssignments'))), createObject('value', variables('roleAssignments')), createObject('value', createArray()))]",
                   "privateEndpoints": {

--- a/infra/avm/main.json
+++ b/infra/avm/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "1138736693056161647"
+      "templateHash": "2782862649368459379"
     }
   },
   "parameters": {
@@ -195,9 +195,9 @@
     },
     "containerRegistryName": {
       "type": "string",
-      "defaultValue": "dataagentscontainerreg",
+      "defaultValue": "",
       "metadata": {
-        "description": "Optional. Name of the Azure Container Registry."
+        "description": "Optional. Name of the Azure Container Registry. Empty derives a per-deployment name (cr<suffix>)."
       }
     },
     "backendRuntimeStack": {
@@ -330,6 +330,8 @@
   },
   "variables": {
     "solutionSuffix": "[toLower(trim(replace(replace(replace(replace(replace(replace(format('{0}{1}', parameters('solutionName'), parameters('solutionUniqueText')), '-', ''), '_', ''), '.', ''), '/', ''), ' ', ''), '*', '')))]",
+    "containerRegistryResourceName": "[if(not(empty(parameters('containerRegistryName'))), parameters('containerRegistryName'), take(format('cr{0}', variables('solutionSuffix')), 50))]",
+    "placeholderContainerImage": "DOCKER|mcr.microsoft.com/azuredocs/aci-helloworld:latest",
     "deployerInfo": "[deployer()]",
     "deployingUserPrincipalId": "[variables('deployerInfo').objectId]",
     "createdBy": "[if(contains(variables('deployerInfo'), 'userPrincipalName'), split(variables('deployerInfo').userPrincipalName, '@')[0], variables('deployerInfo').objectId)]",
@@ -375,7 +377,8 @@
       "privatelink.blob.core.windows.net",
       "privatelink.search.windows.net",
       "privatelink.database.windows.net",
-      "privatelink.azurewebsites.net"
+      "privatelink.azurewebsites.net",
+      "privatelink.azurecr.io"
     ],
     "dnsZoneIndex": {
       "cognitiveServices": 0,
@@ -385,7 +388,8 @@
       "blob": 4,
       "search": 5,
       "sqlServer": 6,
-      "webApp": 7
+      "webApp": 7,
+      "containerRegistry": 8
     },
     "aiModelDeployments": [
       {
@@ -45744,6 +45748,4108 @@
         "virtualNetwork"
       ]
     },
+    "containerRegistry": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[take(format('module.container-registry.{0}', parameters('solutionName')), 64)]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "solutionName": {
+            "value": "[variables('solutionSuffix')]"
+          },
+          "name": {
+            "value": "[variables('containerRegistryResourceName')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[parameters('tags')]"
+          },
+          "enableTelemetry": {
+            "value": "[parameters('enableTelemetry')]"
+          },
+          "sku": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Premium'), createObject('value', 'Standard'))]",
+          "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
+          "networkRuleSetDefaultAction": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Deny'), createObject('value', 'Allow'))]",
+          "exportPolicyStatus": "[if(parameters('enablePrivateNetworking'), createObject('value', 'disabled'), createObject('value', 'enabled'))]",
+          "enablePrivateNetworking": {
+            "value": "[parameters('enablePrivateNetworking')]"
+          },
+          "privateEndpointSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.backendSubnetResourceId.value), createObject('value', ''))]",
+          "privateDnsZoneResourceIds": "[if(parameters('enablePrivateNetworking'), createObject('value', createArray(reference(format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').containerRegistry)).outputs.resourceId.value)), createObject('value', createArray()))]"
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.44.1.10279",
+              "templateHash": "1223988259594936060"
+            }
+          },
+          "parameters": {
+            "solutionName": {
+              "type": "string",
+              "metadata": {
+                "description": "Solution name used for naming convention."
+              }
+            },
+            "name": {
+              "type": "string",
+              "defaultValue": "[replace(format('cr{0}', parameters('solutionName')), '-', '')]",
+              "metadata": {
+                "description": "Name of the container registry."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Azure region for deployment."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Resource tags."
+              }
+            },
+            "sku": {
+              "type": "string",
+              "defaultValue": "Standard",
+              "allowedValues": [
+                "Basic",
+                "Standard",
+                "Premium"
+              ],
+              "metadata": {
+                "description": "SKU for the container registry."
+              }
+            },
+            "adminUserEnabled": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Enable admin user for the registry."
+              }
+            },
+            "publicNetworkAccess": {
+              "type": "string",
+              "defaultValue": "Enabled",
+              "allowedValues": [
+                "Enabled",
+                "Disabled"
+              ],
+              "metadata": {
+                "description": "Public network access setting."
+              }
+            },
+            "exportPolicyStatus": {
+              "type": "string",
+              "defaultValue": "enabled",
+              "metadata": {
+                "description": "Export policy status. Must be \"enabled\" when publicNetworkAccess is \"Enabled\"."
+              }
+            },
+            "acrPullPrincipalIds": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Principal IDs to assign AcrPull role."
+              }
+            },
+            "acrPushPrincipalIds": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Principal IDs to assign AcrPush role (typically the deployer)."
+              }
+            },
+            "acrPushPrincipalType": {
+              "type": "string",
+              "defaultValue": "User",
+              "allowedValues": [
+                "User",
+                "ServicePrincipal",
+                "Group"
+              ],
+              "metadata": {
+                "description": "Principal type for AcrPush assignments (User for azd user, ServicePrincipal for CI)."
+              }
+            },
+            "enablePrivateNetworking": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Enable private networking."
+              }
+            },
+            "privateEndpointSubnetId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Subnet resource ID for private endpoint."
+              }
+            },
+            "privateDnsZoneResourceIds": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Private DNS zone resource IDs for private endpoint."
+              }
+            },
+            "networkRuleSetDefaultAction": {
+              "type": "string",
+              "defaultValue": "Allow",
+              "allowedValues": [
+                "Allow",
+                "Deny"
+              ],
+              "metadata": {
+                "description": "Default action for the network rule set. Use Allow when no private endpoint is in place; Deny for private-only."
+              }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Enable Azure telemetry collection."
+              }
+            },
+            "managedIdentities": {
+              "type": "object",
+              "defaultValue": {
+                "systemAssigned": true
+              },
+              "metadata": {
+                "description": "Optional. Managed identities for the resource."
+              }
+            }
+          },
+          "variables": {
+            "copy": [
+              {
+                "name": "pullRoleAssignments",
+                "count": "[length(parameters('acrPullPrincipalIds'))]",
+                "input": {
+                  "principalId": "[parameters('acrPullPrincipalIds')[copyIndex('pullRoleAssignments')]]",
+                  "roleDefinitionIdOrName": "[variables('acrPullRoleId')]",
+                  "principalType": "ServicePrincipal"
+                }
+              },
+              {
+                "name": "pushRoleAssignments",
+                "count": "[length(parameters('acrPushPrincipalIds'))]",
+                "input": {
+                  "principalId": "[parameters('acrPushPrincipalIds')[copyIndex('pushRoleAssignments')]]",
+                  "roleDefinitionIdOrName": "[variables('acrPushRoleId')]",
+                  "principalType": "[parameters('acrPushPrincipalType')]"
+                }
+              },
+              {
+                "name": "dnsZoneConfigs",
+                "count": "[length(parameters('privateDnsZoneResourceIds'))]",
+                "input": {
+                  "name": "[format('config{0}', copyIndex('dnsZoneConfigs'))]",
+                  "privateDnsZoneResourceId": "[parameters('privateDnsZoneResourceIds')[copyIndex('dnsZoneConfigs')]]"
+                }
+              }
+            ],
+            "acrPullRoleId": "7f951dda-4ed3-4680-a7ca-43fe172d538d",
+            "acrPushRoleId": "8311e382-0749-4cb8-b61a-304f252e45ec",
+            "roleAssignments": "[concat(if(not(empty(parameters('acrPullPrincipalIds'))), variables('pullRoleAssignments'), createArray()), if(not(empty(parameters('acrPushPrincipalIds'))), variables('pushRoleAssignments'), createArray()))]",
+            "privateEndpointConfig": "[if(and(parameters('enablePrivateNetworking'), not(empty(parameters('privateEndpointSubnetId')))), createArray(createObject('subnetResourceId', parameters('privateEndpointSubnetId'), 'privateDnsZoneGroup', if(not(empty(parameters('privateDnsZoneResourceIds'))), createObject('privateDnsZoneGroupConfigs', variables('dnsZoneConfigs')), null()))), createArray())]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[take(format('avm.res.containerregistry.{0}', parameters('name')), 64)]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[parameters('name')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "tags": {
+                    "value": "[parameters('tags')]"
+                  },
+                  "enableTelemetry": {
+                    "value": "[parameters('enableTelemetry')]"
+                  },
+                  "acrSku": {
+                    "value": "[parameters('sku')]"
+                  },
+                  "acrAdminUserEnabled": {
+                    "value": "[parameters('adminUserEnabled')]"
+                  },
+                  "publicNetworkAccess": {
+                    "value": "[parameters('publicNetworkAccess')]"
+                  },
+                  "exportPolicyStatus": {
+                    "value": "[parameters('exportPolicyStatus')]"
+                  },
+                  "roleAssignments": "[if(not(empty(variables('roleAssignments'))), createObject('value', variables('roleAssignments')), createObject('value', createArray()))]",
+                  "privateEndpoints": {
+                    "value": "[variables('privateEndpointConfig')]"
+                  },
+                  "networkRuleSetDefaultAction": {
+                    "value": "[parameters('networkRuleSetDefaultAction')]"
+                  },
+                  "managedIdentities": {
+                    "value": "[parameters('managedIdentities')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.42.1.51946",
+                      "templateHash": "1509121545318808417"
+                    },
+                    "name": "Azure Container Registries (ACR)",
+                    "description": "This module deploys an Azure Container Registry (ACR)."
+                  },
+                  "definitions": {
+                    "privateEndpointOutputType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "The name of the private endpoint."
+                          }
+                        },
+                        "resourceId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "The resource ID of the private endpoint."
+                          }
+                        },
+                        "groupId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "The group Id for the private endpoint Group."
+                          }
+                        },
+                        "customDnsConfigs": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fqdn": {
+                                "type": "string",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "FQDN that resolves to private endpoint IP address."
+                                }
+                              },
+                              "ipAddresses": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "metadata": {
+                                  "description": "A list of private IP addresses of the private endpoint."
+                                }
+                              }
+                            }
+                          },
+                          "metadata": {
+                            "description": "The custom DNS configurations of the private endpoint."
+                          }
+                        },
+                        "networkInterfaceResourceIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "description": "The IDs of the network interfaces associated with the private endpoint."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true
+                      }
+                    },
+                    "credentialSetType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the credential set."
+                          }
+                        },
+                        "managedIdentities": {
+                          "$ref": "#/definitions/managedIdentityOnlySysAssignedType",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The managed identity definition for this resource."
+                          }
+                        },
+                        "authCredentials": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/authCredentialsType"
+                          },
+                          "metadata": {
+                            "description": "Required. List of authentication credentials stored for an upstream. Usually consists of a primary and an optional secondary credential."
+                          }
+                        },
+                        "loginServer": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The credentials are stored for this upstream or login server."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type for a credential set."
+                      }
+                    },
+                    "scopeMapsType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the scope map."
+                          }
+                        },
+                        "actions": {
+                          "type": "array",
+                          "metadata": {
+                            "__bicep_resource_derived_type!": {
+                              "source": "Microsoft.ContainerRegistry/registries/scopeMaps@2025-03-01-preview#properties/properties/properties/actions"
+                            },
+                            "description": "Required. The list of scoped permissions for registry artifacts."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The user friendly description of the scope map."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type for a scope map."
+                      }
+                    },
+                    "cacheRuleType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the cache rule. Will be derived from the source repository name if not defined."
+                          }
+                        },
+                        "sourceRepository": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. Source repository pulled from upstream."
+                          }
+                        },
+                        "targetRepository": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Target repository specified in docker pull command. E.g.: docker pull myregistry.azurecr.io/{targetRepository}:{tag}."
+                          }
+                        },
+                        "credentialSetResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The resource ID of the credential store which is associated with the cache rule."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type for a cache rule."
+                      }
+                    },
+                    "replicationType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the replication."
+                          }
+                        },
+                        "location": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Location for all resources."
+                          }
+                        },
+                        "tags": {
+                          "type": "object",
+                          "metadata": {
+                            "__bicep_resource_derived_type!": {
+                              "source": "Microsoft.ContainerRegistry/registries/replications@2025-03-01-preview#properties/tags"
+                            },
+                            "description": "Optional. Tags of the resource."
+                          },
+                          "nullable": true
+                        },
+                        "regionEndpointEnabled": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specifies whether the replication regional endpoint is enabled. Requests will not be routed to a replication whose regional endpoint is disabled, however its data will continue to be synced with other replications."
+                          }
+                        },
+                        "zoneRedundancy": {
+                          "type": "string",
+                          "metadata": {
+                            "__bicep_resource_derived_type!": {
+                              "source": "Microsoft.ContainerRegistry/registries@2025-03-01-preview#properties/properties/properties/zoneRedundancy"
+                            },
+                            "description": "Optional. Whether or not zone redundancy is enabled for this container registry."
+                          },
+                          "nullable": true
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type for a replication."
+                      }
+                    },
+                    "taskType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the task."
+                          }
+                        },
+                        "location": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Location for all resources."
+                          }
+                        },
+                        "tags": {
+                          "type": "object",
+                          "metadata": {
+                            "__bicep_resource_derived_type!": {
+                              "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/tags"
+                            },
+                            "description": "Optional. Tags of the resource."
+                          },
+                          "nullable": true
+                        },
+                        "platform": {
+                          "type": "object",
+                          "metadata": {
+                            "__bicep_resource_derived_type!": {
+                              "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/platform"
+                            },
+                            "description": "Optional. The platform properties for the task."
+                          },
+                          "nullable": true
+                        },
+                        "step": {
+                          "type": "object",
+                          "metadata": {
+                            "__bicep_resource_derived_type!": {
+                              "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/step"
+                            },
+                            "description": "Optional. The step properties for the task."
+                          },
+                          "nullable": true
+                        },
+                        "trigger": {
+                          "type": "object",
+                          "metadata": {
+                            "__bicep_resource_derived_type!": {
+                              "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/trigger"
+                            },
+                            "description": "Optional. The trigger properties for the task."
+                          },
+                          "nullable": true
+                        },
+                        "status": {
+                          "type": "string",
+                          "metadata": {
+                            "__bicep_resource_derived_type!": {
+                              "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/status"
+                            },
+                            "description": "Optional. The status of the task at the time the operation was called."
+                          },
+                          "nullable": true
+                        },
+                        "timeout": {
+                          "type": "int",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The timeout in seconds for the task to run before it is automatically disabled."
+                          }
+                        },
+                        "agentConfiguration": {
+                          "type": "object",
+                          "metadata": {
+                            "__bicep_resource_derived_type!": {
+                              "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/agentConfiguration"
+                            },
+                            "description": "Optional. The agent configuration for the task."
+                          },
+                          "nullable": true
+                        },
+                        "agentPoolName": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the agent pool to run the task on. If not specified, the task will run on Microsoft-hosted agents."
+                          }
+                        },
+                        "isSystemTask": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Whether this is a system task or not. System tasks have some additional restrictions and are used for internal purposes by Microsoft services, such as Azure DevOps pipelines integration."
+                          }
+                        },
+                        "logTemplate": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The log template for the task to use when creating logs in Log Analytics."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type for a task."
+                      }
+                    },
+                    "tokenType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the token."
+                          }
+                        },
+                        "scopeMapResourceId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The resource ID of the scope map which defines the permissions for this token."
+                          }
+                        },
+                        "status": {
+                          "type": "string",
+                          "metadata": {
+                            "__bicep_resource_derived_type!": {
+                              "source": "Microsoft.ContainerRegistry/registries/tokens@2025-11-01#properties/properties/properties/status"
+                            },
+                            "description": "Optional. The status of the token at the time the operation was called."
+                          },
+                          "nullable": true
+                        },
+                        "credentials": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/authCredentialsType"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The list of credentials associated with the token. Usually consists of a primary and an optional secondary credential."
+                          }
+                        }
+                      }
+                    },
+                    "webhookType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "minLength": 5,
+                          "maxLength": 50,
+                          "metadata": {
+                            "description": "Optional. The name of the registry webhook."
+                          }
+                        },
+                        "serviceUri": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The service URI for the webhook to post notifications."
+                          }
+                        },
+                        "status": {
+                          "type": "string",
+                          "metadata": {
+                            "__bicep_resource_derived_type!": {
+                              "source": "Microsoft.ContainerRegistry/registries/webhooks@2025-03-01-preview#properties/properties/properties/status"
+                            },
+                            "description": "Optional. The status of the webhook at the time the operation was called."
+                          },
+                          "nullable": true
+                        },
+                        "action": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The list of actions that trigger the webhook to post notifications."
+                          }
+                        },
+                        "location": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Location for all resources."
+                          }
+                        },
+                        "tags": {
+                          "type": "object",
+                          "metadata": {
+                            "__bicep_resource_derived_type!": {
+                              "source": "Microsoft.ContainerRegistry/registries/webhooks@2025-03-01-preview#properties/tags"
+                            },
+                            "description": "Optional. Tags of the resource."
+                          },
+                          "nullable": true
+                        },
+                        "customHeaders": {
+                          "type": "object",
+                          "metadata": {
+                            "__bicep_resource_derived_type!": {
+                              "source": "Microsoft.ContainerRegistry/registries/webhooks@2025-03-01-preview#properties/properties/properties/customHeaders"
+                            },
+                            "description": "Optional. Custom headers that will be added to the webhook notifications."
+                          },
+                          "nullable": true
+                        },
+                        "scope": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The scope of repositories where the event can be triggered. For example, 'foo:*' means events for all tags under repository 'foo'. 'foo:bar' means events for 'foo:bar' only. 'foo' is equivalent to 'foo:latest'. Empty means all events."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type for a webhook."
+                      }
+                    },
+                    "_1.privateEndpointCustomDnsConfigType": {
+                      "type": "object",
+                      "properties": {
+                        "fqdn": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. FQDN that resolves to private endpoint IP address."
+                          }
+                        },
+                        "ipAddresses": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "description": "Required. A list of private IP addresses of the private endpoint."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                        }
+                      }
+                    },
+                    "_1.privateEndpointIpConfigurationType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the resource that is unique within a resource group."
+                          }
+                        },
+                        "properties": {
+                          "type": "object",
+                          "properties": {
+                            "groupId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to."
+                              }
+                            },
+                            "memberName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to."
+                              }
+                            },
+                            "privateIPAddress": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. A private IP address obtained from the private endpoint's subnet."
+                              }
+                            }
+                          },
+                          "metadata": {
+                            "description": "Required. Properties of private endpoint IP configurations."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                        }
+                      }
+                    },
+                    "_1.privateEndpointPrivateDnsZoneGroupType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the Private DNS Zone Group."
+                          }
+                        },
+                        "privateDnsZoneGroupConfigs": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. The name of the private DNS Zone Group config."
+                                }
+                              },
+                              "privateDnsZoneResourceId": {
+                                "type": "string",
+                                "metadata": {
+                                  "description": "Required. The resource id of the private DNS zone."
+                                }
+                              }
+                            }
+                          },
+                          "metadata": {
+                            "description": "Required. The private DNS Zone Groups to associate the Private Endpoint. A DNS Zone Group can support up to 5 DNS zones."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                        }
+                      }
+                    },
+                    "authCredentialsType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the credential."
+                          }
+                        },
+                        "usernameSecretIdentifier": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. KeyVault Secret URI for accessing the username."
+                          }
+                        },
+                        "passwordSecretIdentifier": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. KeyVault Secret URI for accessing the password."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "The type for auth credentials.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "credential-set/main.bicep"
+                        }
+                      }
+                    },
+                    "customerManagedKeyWithAutoRotateType": {
+                      "type": "object",
+                      "properties": {
+                        "keyVaultResourceId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The resource ID of a key vault to reference a customer managed key for encryption from."
+                          }
+                        },
+                        "keyName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the customer managed key to use for encryption."
+                          }
+                        },
+                        "keyVersion": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting."
+                          }
+                        },
+                        "autoRotationEnabled": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used."
+                          }
+                        },
+                        "userAssignedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a customer-managed key. To be used if the resource type supports auto-rotation of the customer-managed key.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                        }
+                      }
+                    },
+                    "diagnosticSettingFullType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the diagnostic setting."
+                          }
+                        },
+                        "logCategoriesAndGroups": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "category": {
+                                "type": "string",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
+                                }
+                              },
+                              "categoryGroup": {
+                                "type": "string",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
+                                }
+                              },
+                              "enabled": {
+                                "type": "bool",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                                }
+                              }
+                            }
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
+                          }
+                        },
+                        "metricCategories": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "category": {
+                                "type": "string",
+                                "metadata": {
+                                  "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
+                                }
+                              },
+                              "enabled": {
+                                "type": "bool",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                                }
+                              }
+                            }
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
+                          }
+                        },
+                        "logAnalyticsDestinationType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "AzureDiagnostics",
+                            "Dedicated"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
+                          }
+                        },
+                        "workspaceResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                          }
+                        },
+                        "storageAccountResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                          }
+                        },
+                        "eventHubAuthorizationRuleResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
+                          }
+                        },
+                        "eventHubName": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                          }
+                        },
+                        "marketplacePartnerResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                        }
+                      }
+                    },
+                    "lockType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the name of lock."
+                          }
+                        },
+                        "kind": {
+                          "type": "string",
+                          "allowedValues": [
+                            "CanNotDelete",
+                            "None",
+                            "ReadOnly"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the type of lock."
+                          }
+                        },
+                        "notes": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the notes of the lock."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a lock.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                        }
+                      }
+                    },
+                    "managedIdentityAllType": {
+                      "type": "object",
+                      "properties": {
+                        "systemAssigned": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Enables system assigned managed identity on the resource."
+                          }
+                        },
+                        "userAssignedResourceIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The resource ID(s) to assign to the resource. Required if a user assigned identity is used for encryption."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                        }
+                      }
+                    },
+                    "managedIdentityOnlySysAssignedType": {
+                      "type": "object",
+                      "properties": {
+                        "systemAssigned": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Enables system assigned managed identity on the resource."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a managed identity configuration. To be used if only system-assigned identities are supported by the resource provider.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                        }
+                      }
+                    },
+                    "privateEndpointSingleServiceType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the Private Endpoint."
+                          }
+                        },
+                        "location": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The location to deploy the Private Endpoint to."
+                          }
+                        },
+                        "privateLinkServiceConnectionName": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the private link connection to create."
+                          }
+                        },
+                        "service": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The subresource to deploy the Private Endpoint for. For example \"vault\" for a Key Vault Private Endpoint."
+                          }
+                        },
+                        "subnetResourceId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                          }
+                        },
+                        "resourceGroupResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The resource ID of the Resource Group the Private Endpoint will be created in. If not specified, the Resource Group of the provided Virtual Network Subnet is used."
+                          }
+                        },
+                        "privateDnsZoneGroup": {
+                          "$ref": "#/definitions/_1.privateEndpointPrivateDnsZoneGroupType",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The private DNS Zone Group to configure for the Private Endpoint."
+                          }
+                        },
+                        "isManualConnection": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. If Manual Private Link Connection is required."
+                          }
+                        },
+                        "manualConnectionRequestMessage": {
+                          "type": "string",
+                          "nullable": true,
+                          "maxLength": 140,
+                          "metadata": {
+                            "description": "Optional. A message passed to the owner of the remote resource with the manual connection request."
+                          }
+                        },
+                        "customDnsConfigs": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/_1.privateEndpointCustomDnsConfigType"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Custom DNS configurations."
+                          }
+                        },
+                        "ipConfigurations": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/_1.privateEndpointIpConfigurationType"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. A list of IP configurations of the Private Endpoint. This will be used to map to the first-party Service endpoints."
+                          }
+                        },
+                        "applicationSecurityGroupResourceIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Application security groups in which the Private Endpoint IP configuration is included."
+                          }
+                        },
+                        "customNetworkInterfaceName": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The custom name of the network interface attached to the Private Endpoint."
+                          }
+                        },
+                        "lock": {
+                          "$ref": "#/definitions/lockType",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the type of lock."
+                          }
+                        },
+                        "roleAssignments": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/roleAssignmentType"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Array of role assignments to create."
+                          }
+                        },
+                        "tags": {
+                          "type": "object",
+                          "nullable": true,
+                          "metadata": {
+                            "__bicep_resource_derived_type!": {
+                              "source": "Microsoft.Network/privateEndpoints@2024-07-01#properties/tags"
+                            },
+                            "description": "Optional. Tags to be applied on all resources/Resource Groups in this deployment."
+                          }
+                        },
+                        "enableTelemetry": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Enable/Disable usage telemetry for module."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a private endpoint. To be used if the private endpoint's default service / groupId can be assumed (i.e., for services that only have one Private Endpoint type like 'vault' for key vault).",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                        }
+                      }
+                    },
+                    "roleAssignmentType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          }
+                        },
+                        "roleDefinitionIdOrName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                          }
+                        },
+                        "principalId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                          }
+                        },
+                        "principalType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "Device",
+                            "ForeignGroup",
+                            "Group",
+                            "ServicePrincipal",
+                            "User"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The principal type of the assigned principal ID."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The description of the role assignment."
+                          }
+                        },
+                        "condition": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                          }
+                        },
+                        "conditionVersion": {
+                          "type": "string",
+                          "allowedValues": [
+                            "2.0"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Version of the condition."
+                          }
+                        },
+                        "delegatedManagedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The Resource Id of the delegated managed identity resource."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a role assignment.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                        }
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 5,
+                      "maxLength": 50,
+                      "metadata": {
+                        "description": "Required. Name of your Azure Container Registry."
+                      }
+                    },
+                    "acrAdminUserEnabled": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Enable admin user that have push / pull permission to the registry."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().location]",
+                      "metadata": {
+                        "description": "Optional. Location for all resources."
+                      }
+                    },
+                    "roleAssignments": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/roleAssignmentType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Array of role assignments to create."
+                      }
+                    },
+                    "autoGeneratedDomainNameLabelScope": {
+                      "type": "string",
+                      "nullable": true,
+                      "allowedValues": [
+                        "NoReuse",
+                        "ResourceGroupReuse",
+                        "SubscriptionReuse",
+                        "TenantReuse",
+                        "Unsecure"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The domain name label reuse scope."
+                      }
+                    },
+                    "roleAssignmentMode": {
+                      "type": "string",
+                      "nullable": true,
+                      "allowedValues": [
+                        "AbacRepositoryPermissions",
+                        "LegacyRegistryPermissions"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The registry permissions role assignment mode."
+                      }
+                    },
+                    "acrSku": {
+                      "type": "string",
+                      "defaultValue": "Premium",
+                      "allowedValues": [
+                        "Basic",
+                        "Premium",
+                        "Standard"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Tier of your Azure container registry."
+                      }
+                    },
+                    "exportPolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "disabled",
+                      "allowedValues": [
+                        "disabled",
+                        "enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The value that indicates whether the export policy is enabled or not."
+                      }
+                    },
+                    "quarantinePolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "disabled",
+                      "allowedValues": [
+                        "disabled",
+                        "enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The value that indicates whether the quarantine policy is enabled or not. Note, requires the 'acrSku' to be 'Premium'."
+                      }
+                    },
+                    "trustPolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "disabled",
+                      "allowedValues": [
+                        "disabled",
+                        "enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The value that indicates whether the trust policy is enabled or not. Note, requires the 'acrSku' to be 'Premium'."
+                      }
+                    },
+                    "retentionPolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "enabled",
+                      "allowedValues": [
+                        "disabled",
+                        "enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The value that indicates whether the retention policy is enabled or not."
+                      }
+                    },
+                    "retentionPolicyDays": {
+                      "type": "int",
+                      "defaultValue": 15,
+                      "metadata": {
+                        "description": "Optional. The number of days to retain an untagged manifest after which it gets purged."
+                      }
+                    },
+                    "azureADAuthenticationAsArmPolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "disabled",
+                      "allowedValues": [
+                        "disabled",
+                        "enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The value that indicates whether the policy for using ARM audience token for a container registry is enabled or not. Default is disabled."
+                      }
+                    },
+                    "softDeletePolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "disabled",
+                      "allowedValues": [
+                        "disabled",
+                        "enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Soft Delete policy status. Default is disabled."
+                      }
+                    },
+                    "softDeletePolicyDays": {
+                      "type": "int",
+                      "defaultValue": 7,
+                      "metadata": {
+                        "description": "Optional. The number of days after which a soft-deleted item is permanently deleted."
+                      }
+                    },
+                    "dataEndpointEnabled": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Enable a single data endpoint per region for serving data. Not relevant in case of disabled public access. Note, requires the 'acrSku' to be 'Premium'."
+                      }
+                    },
+                    "publicNetworkAccess": {
+                      "type": "string",
+                      "nullable": true,
+                      "allowedValues": [
+                        "Enabled",
+                        "Disabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and networkRuleSetIpRules are not set.  Note, requires the 'acrSku' to be 'Premium'."
+                      }
+                    },
+                    "networkRuleBypassOptions": {
+                      "type": "string",
+                      "defaultValue": "AzureServices",
+                      "allowedValues": [
+                        "AzureServices",
+                        "None"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Whether to allow trusted Azure services to access a network restricted registry."
+                      }
+                    },
+                    "networkRuleSetDefaultAction": {
+                      "type": "string",
+                      "defaultValue": "Deny",
+                      "allowedValues": [
+                        "Allow",
+                        "Deny"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The default action of allow or deny when no other rules match."
+                      }
+                    },
+                    "networkRuleSetIpRules": {
+                      "type": "array",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The IP ACL rules. Note, requires the 'acrSku' to be 'Premium'. Set to an empty array to explicitly configure no allowed IPs."
+                      }
+                    },
+                    "privateEndpoints": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/privateEndpointSingleServiceType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. Note, requires the 'acrSku' to be 'Premium'."
+                      }
+                    },
+                    "zoneRedundancy": {
+                      "type": "string",
+                      "defaultValue": "Enabled",
+                      "allowedValues": [
+                        "Disabled",
+                        "Enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Whether or not zone redundancy is enabled for this container registry."
+                      }
+                    },
+                    "replications": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/replicationType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. All replications to create."
+                      }
+                    },
+                    "webhooks": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/webhookType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. All webhooks to create."
+                      }
+                    },
+                    "lock": {
+                      "$ref": "#/definitions/lockType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The lock settings of the service."
+                      }
+                    },
+                    "managedIdentities": {
+                      "$ref": "#/definitions/managedIdentityAllType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The managed identity definition for this resource."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "metadata": {
+                        "__bicep_resource_derived_type!": {
+                          "source": "Microsoft.ContainerRegistry/registries@2025-04-01#properties/tags"
+                        },
+                        "description": "Optional. Tags of the resource."
+                      },
+                      "nullable": true
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    },
+                    "diagnosticSettings": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/diagnosticSettingFullType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The diagnostic settings of the service. If neither metrics nor logs are specified, all metrics & logs are configured by default. If either one is specified, the other is ignored."
+                      }
+                    },
+                    "anonymousPullEnabled": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Enables registry-wide pull from unauthenticated clients. It's in preview and available in the Standard and Premium service tiers."
+                      }
+                    },
+                    "customerManagedKey": {
+                      "$ref": "#/definitions/customerManagedKeyWithAutoRotateType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The customer managed key definition."
+                      }
+                    },
+                    "cacheRules": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/cacheRuleType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Array of Cache Rules."
+                      }
+                    },
+                    "credentialSets": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/credentialSetType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Array of Credential Sets."
+                      }
+                    },
+                    "scopeMaps": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/scopeMapsType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Scope maps setting."
+                      }
+                    },
+                    "tokens": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/tokenType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tokens to create for the container registry."
+                      }
+                    },
+                    "tasks": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/taskType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Array of ACR Tasks to create."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "copy": [
+                      {
+                        "name": "formattedRoleAssignments",
+                        "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                        "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                      }
+                    ],
+                    "enableReferencedModulesTelemetry": false,
+                    "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
+                    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned, UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
+                    "builtInRoleNames": {
+                      "AcrDelete": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c2f4ef07-c644-48eb-af81-4b1b4947fb11')]",
+                      "AcrImageSigner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '6cef56e8-d556-48e5-a04f-b8e64114680f')]",
+                      "AcrPull": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
+                      "AcrPush": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8311e382-0749-4cb8-b61a-304f252e45ec')]",
+                      "AcrQuarantineReader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'cdda3590-29a3-44f6-95f2-9f980659eb04')]",
+                      "AcrQuarantineWriter": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c8d4ff99-41c3-41a8-9f60-21dfdad59608')]",
+                      "Container Registry Repository Catalog Lister": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'bfdb9389-c9a5-478a-bb2f-ba9ca092c3c7')]",
+                      "Container Registry Repository Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2efddaa5-3f1f-4df3-97df-af3f13818f4c')]",
+                      "Container Registry Repository Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b93aa761-3e63-49ed-ac28-beffa264f7ac')]",
+                      "Container Registry Repository Writer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2a1e307c-b015-4ebd-883e-5b7698a07328')]",
+                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
+                    },
+                    "publicNetworkAccessMode": "[if(not(empty(parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(and(not(empty(parameters('privateEndpoints'))), empty(parameters('networkRuleSetIpRules'))), 'Disabled', null()))]",
+                    "shouldConfigureNetworkRuleSet": "[or(not(equals(parameters('networkRuleSetIpRules'), null())), and(equals(variables('publicNetworkAccessMode'), 'Enabled'), equals(parameters('networkRuleSetDefaultAction'), 'Deny')))]"
+                  },
+                  "resources": {
+                    "cMKKeyVault::cMKKey": {
+                      "condition": "[and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName')))))]",
+                      "existing": true,
+                      "type": "Microsoft.KeyVault/vaults/keys",
+                      "apiVersion": "2024-11-01",
+                      "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+                      "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+                      "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]"
+                    },
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('46d3xbcp.res.containerregistry-registry.{0}.{1}', replace('0.12.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "cMKKeyVault": {
+                      "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId')))]",
+                      "existing": true,
+                      "type": "Microsoft.KeyVault/vaults",
+                      "apiVersion": "2024-11-01",
+                      "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+                      "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+                      "name": "[last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/'))]"
+                    },
+                    "cMKUserAssignedIdentity": {
+                      "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId')))]",
+                      "existing": true,
+                      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+                      "apiVersion": "2024-11-30",
+                      "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[2]]",
+                      "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[4]]",
+                      "name": "[last(split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/'))]"
+                    },
+                    "registry": {
+                      "type": "Microsoft.ContainerRegistry/registries",
+                      "apiVersion": "2025-06-01-preview",
+                      "name": "[parameters('name')]",
+                      "location": "[parameters('location')]",
+                      "identity": "[variables('identity')]",
+                      "tags": "[parameters('tags')]",
+                      "sku": {
+                        "name": "[parameters('acrSku')]"
+                      },
+                      "properties": {
+                        "anonymousPullEnabled": "[parameters('anonymousPullEnabled')]",
+                        "adminUserEnabled": "[parameters('acrAdminUserEnabled')]",
+                        "autoGeneratedDomainNameLabelScope": "[parameters('autoGeneratedDomainNameLabelScope')]",
+                        "roleAssignmentMode": "[parameters('roleAssignmentMode')]",
+                        "encryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('status', 'enabled', 'keyVaultProperties', createObject('identity', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), ''))), reference('cMKUserAssignedIdentity').clientId, null()), 'keyIdentifier', if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion')), if(coalesce(tryGet(parameters('customerManagedKey'), 'autoRotationEnabled'), true()), reference('cMKKeyVault::cMKKey').keyUri, reference('cMKKeyVault::cMKKey').keyUriWithVersion)))), null())]",
+                        "policies": {
+                          "azureADAuthenticationAsArmPolicy": {
+                            "status": "[parameters('azureADAuthenticationAsArmPolicyStatus')]"
+                          },
+                          "exportPolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('status', parameters('exportPolicyStatus')), null())]",
+                          "quarantinePolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('status', parameters('quarantinePolicyStatus')), null())]",
+                          "trustPolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('type', 'Notary', 'status', parameters('trustPolicyStatus')), null())]",
+                          "retentionPolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('days', parameters('retentionPolicyDays'), 'status', parameters('retentionPolicyStatus')), null())]",
+                          "softDeletePolicy": {
+                            "retentionDays": "[parameters('softDeletePolicyDays')]",
+                            "status": "[parameters('softDeletePolicyStatus')]"
+                          }
+                        },
+                        "dataEndpointEnabled": "[parameters('dataEndpointEnabled')]",
+                        "publicNetworkAccess": "[variables('publicNetworkAccessMode')]",
+                        "networkRuleBypassOptions": "[parameters('networkRuleBypassOptions')]",
+                        "networkRuleSet": "[if(variables('shouldConfigureNetworkRuleSet'), createObject('defaultAction', parameters('networkRuleSetDefaultAction'), 'ipRules', coalesce(parameters('networkRuleSetIpRules'), createArray())), null())]",
+                        "zoneRedundancy": "[if(equals(parameters('acrSku'), 'Premium'), parameters('zoneRedundancy'), null())]"
+                      },
+                      "dependsOn": [
+                        "cMKKeyVault::cMKKey",
+                        "cMKUserAssignedIdentity"
+                      ]
+                    },
+                    "registry_lock": {
+                      "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                      "type": "Microsoft.Authorization/locks",
+                      "apiVersion": "2020-05-01",
+                      "scope": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]",
+                      "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                      "properties": {
+                        "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                        "notes": "[coalesce(tryGet(parameters('lock'), 'notes'), if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.'))]"
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_diagnosticSettings": {
+                      "copy": {
+                        "name": "registry_diagnosticSettings",
+                        "count": "[length(coalesce(parameters('diagnosticSettings'), createArray()))]"
+                      },
+                      "type": "Microsoft.Insights/diagnosticSettings",
+                      "apiVersion": "2021-05-01-preview",
+                      "scope": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]",
+                      "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
+                      "properties": {
+                        "copy": [
+                          {
+                            "name": "metrics",
+                            "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups')), createArray(createObject('category', 'AllMetrics')), createArray())))]",
+                            "input": {
+                              "category": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups')), createArray(createObject('category', 'AllMetrics')), createArray()))[copyIndex('metrics')].category]",
+                              "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups')), createArray(createObject('category', 'AllMetrics')), createArray()))[copyIndex('metrics')], 'enabled'), true())]",
+                              "timeGrain": null
+                            }
+                          },
+                          {
+                            "name": "logs",
+                            "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories')), createArray(createObject('categoryGroup', 'allLogs')), createArray())))]",
+                            "input": {
+                              "categoryGroup": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories')), createArray(createObject('categoryGroup', 'allLogs')), createArray()))[copyIndex('logs')], 'categoryGroup')]",
+                              "category": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories')), createArray(createObject('categoryGroup', 'allLogs')), createArray()))[copyIndex('logs')], 'category')]",
+                              "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories')), createArray(createObject('categoryGroup', 'allLogs')), createArray()))[copyIndex('logs')], 'enabled'), true())]"
+                            }
+                          }
+                        ],
+                        "storageAccountId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'storageAccountResourceId')]",
+                        "workspaceId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'workspaceResourceId')]",
+                        "eventHubAuthorizationRuleId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubAuthorizationRuleResourceId')]",
+                        "eventHubName": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubName')]",
+                        "marketplacePartnerId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'marketplacePartnerResourceId')]",
+                        "logAnalyticsDestinationType": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logAnalyticsDestinationType')]"
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_roleAssignments": {
+                      "copy": {
+                        "name": "registry_roleAssignments",
+                        "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]",
+                      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                      "properties": {
+                        "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                        "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                        "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                        "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                        "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                        "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                        "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_scopeMaps": {
+                      "copy": {
+                        "name": "registry_scopeMaps",
+                        "count": "[length(coalesce(parameters('scopeMaps'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('{0}-Registry-Scope-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[tryGet(coalesce(parameters('scopeMaps'), createArray())[copyIndex()], 'name')]"
+                          },
+                          "actions": {
+                            "value": "[coalesce(parameters('scopeMaps'), createArray())[copyIndex()].actions]"
+                          },
+                          "description": {
+                            "value": "[tryGet(coalesce(parameters('scopeMaps'), createArray())[copyIndex()], 'description')]"
+                          },
+                          "registryName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "enableTelemetry": {
+                            "value": "[variables('enableReferencedModulesTelemetry')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.42.1.51946",
+                              "templateHash": "3787322352564227867"
+                            },
+                            "name": "Container Registries scope maps",
+                            "description": "This module deploys an Azure Container Registry (ACR) scope map."
+                          },
+                          "parameters": {
+                            "registryName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "defaultValue": "[format('{0}-scopemaps', parameters('registryName'))]",
+                              "metadata": {
+                                "description": "Optional. The name of the scope map."
+                              }
+                            },
+                            "actions": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "description": "Required. The list of scoped permissions for registry artifacts."
+                              }
+                            },
+                            "description": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The user friendly description of the scope map."
+                              }
+                            },
+                            "enableTelemetry": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Enable/Disable usage telemetry for module."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "avmTelemetry": {
+                              "condition": "[parameters('enableTelemetry')]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('46d3xbcp.res.containerregistry-registry-scopemap.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                              "properties": {
+                                "mode": "Incremental",
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "resources": [],
+                                  "outputs": {
+                                    "telemetry": {
+                                      "type": "String",
+                                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "registry": {
+                              "existing": true,
+                              "type": "Microsoft.ContainerRegistry/registries",
+                              "apiVersion": "2025-11-01",
+                              "name": "[parameters('registryName')]"
+                            },
+                            "scopeMap": {
+                              "type": "Microsoft.ContainerRegistry/registries/scopeMaps",
+                              "apiVersion": "2025-11-01",
+                              "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                              "properties": {
+                                "actions": "[parameters('actions')]",
+                                "description": "[parameters('description')]"
+                              }
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the scope map."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the resource group the scope map was created in."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the scope map."
+                              },
+                              "value": "[resourceId('Microsoft.ContainerRegistry/registries/scopeMaps', parameters('registryName'), parameters('name'))]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_replications": {
+                      "copy": {
+                        "name": "registry_replications",
+                        "count": "[length(coalesce(parameters('replications'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('{0}-Registry-Replication-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[coalesce(parameters('replications'), createArray())[copyIndex()].name]"
+                          },
+                          "registryName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "location": {
+                            "value": "[coalesce(parameters('replications'), createArray())[copyIndex()].location]"
+                          },
+                          "regionEndpointEnabled": {
+                            "value": "[tryGet(coalesce(parameters('replications'), createArray())[copyIndex()], 'regionEndpointEnabled')]"
+                          },
+                          "zoneRedundancy": {
+                            "value": "[tryGet(coalesce(parameters('replications'), createArray())[copyIndex()], 'zoneRedundancy')]"
+                          },
+                          "tags": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('replications'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                          },
+                          "enableTelemetry": {
+                            "value": "[variables('enableReferencedModulesTelemetry')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.42.1.51946",
+                              "templateHash": "6219097750044645017"
+                            },
+                            "name": "Azure Container Registry (ACR) Replications",
+                            "description": "This module deploys an Azure Container Registry (ACR) Replication."
+                          },
+                          "parameters": {
+                            "registryName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The name of the replication."
+                              }
+                            },
+                            "location": {
+                              "type": "string",
+                              "defaultValue": "[resourceGroup().location]",
+                              "metadata": {
+                                "description": "Optional. Location for all resources."
+                              }
+                            },
+                            "tags": {
+                              "type": "object",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.ContainerRegistry/registries/replications@2025-11-01#properties/tags"
+                                },
+                                "description": "Optional. Tags of the resource."
+                              },
+                              "nullable": true
+                            },
+                            "regionEndpointEnabled": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Specifies whether the replication regional endpoint is enabled. Requests will not be routed to a replication whose regional endpoint is disabled, however its data will continue to be synced with other replications."
+                              }
+                            },
+                            "zoneRedundancy": {
+                              "type": "string",
+                              "defaultValue": "Disabled",
+                              "allowedValues": [
+                                "Disabled",
+                                "Enabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. Whether or not zone redundancy is enabled for this container registry."
+                              }
+                            },
+                            "enableTelemetry": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Enable/Disable usage telemetry for module."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "avmTelemetry": {
+                              "condition": "[parameters('enableTelemetry')]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('46d3xbcp.res.containerregistry-registry-repl.{0}.{1}', replace('0.1.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                              "properties": {
+                                "mode": "Incremental",
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "resources": [],
+                                  "outputs": {
+                                    "telemetry": {
+                                      "type": "String",
+                                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "registry": {
+                              "existing": true,
+                              "type": "Microsoft.ContainerRegistry/registries",
+                              "apiVersion": "2025-11-01",
+                              "name": "[parameters('registryName')]"
+                            },
+                            "replication": {
+                              "type": "Microsoft.ContainerRegistry/registries/replications",
+                              "apiVersion": "2025-11-01",
+                              "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                              "location": "[parameters('location')]",
+                              "tags": "[parameters('tags')]",
+                              "properties": {
+                                "regionEndpointEnabled": "[parameters('regionEndpointEnabled')]",
+                                "zoneRedundancy": "[parameters('zoneRedundancy')]"
+                              }
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the replication."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the replication."
+                              },
+                              "value": "[resourceId('Microsoft.ContainerRegistry/registries/replications', parameters('registryName'), parameters('name'))]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the resource group the replication was created in."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "location": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The location the resource was deployed into."
+                              },
+                              "value": "[reference('replication', '2025-11-01', 'full').location]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_credentialSets": {
+                      "copy": {
+                        "name": "registry_credentialSets",
+                        "count": "[length(coalesce(parameters('credentialSets'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('{0}-Registry-CredentialSet-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].name]"
+                          },
+                          "registryName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "managedIdentities": {
+                            "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].managedIdentities]"
+                          },
+                          "authCredentials": {
+                            "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].authCredentials]"
+                          },
+                          "loginServer": {
+                            "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].loginServer]"
+                          },
+                          "enableTelemetry": {
+                            "value": "[variables('enableReferencedModulesTelemetry')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.42.1.51946",
+                              "templateHash": "13412699468141336519"
+                            },
+                            "name": "Container Registries Credential Sets",
+                            "description": "This module deploys an ACR Credential Set."
+                          },
+                          "definitions": {
+                            "authCredentialsType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The name of the credential."
+                                  }
+                                },
+                                "usernameSecretIdentifier": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. KeyVault Secret URI for accessing the username."
+                                  }
+                                },
+                                "passwordSecretIdentifier": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. KeyVault Secret URI for accessing the password."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "The type for auth credentials."
+                              }
+                            },
+                            "managedIdentityOnlySysAssignedType": {
+                              "type": "object",
+                              "properties": {
+                                "systemAssigned": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Enables system assigned managed identity on the resource."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a managed identity configuration. To be used if only system-assigned identities are supported by the resource provider.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                }
+                              }
+                            }
+                          },
+                          "parameters": {
+                            "registryName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The name of the credential set."
+                              }
+                            },
+                            "managedIdentities": {
+                              "$ref": "#/definitions/managedIdentityOnlySysAssignedType",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The managed identity definition for this resource."
+                              }
+                            },
+                            "authCredentials": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/authCredentialsType"
+                              },
+                              "metadata": {
+                                "description": "Required. List of authentication credentials stored for an upstream. Usually consists of a primary and an optional secondary credential."
+                              }
+                            },
+                            "loginServer": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The credentials are stored for this upstream or login server."
+                              }
+                            },
+                            "enableTelemetry": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Enable/Disable usage telemetry for module."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "avmTelemetry": {
+                              "condition": "[parameters('enableTelemetry')]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('46d3xbcp.res.containerregistry-registry-credset.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                              "properties": {
+                                "mode": "Incremental",
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "resources": [],
+                                  "outputs": {
+                                    "telemetry": {
+                                      "type": "String",
+                                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "registry": {
+                              "existing": true,
+                              "type": "Microsoft.ContainerRegistry/registries",
+                              "apiVersion": "2025-11-01",
+                              "name": "[parameters('registryName')]"
+                            },
+                            "credentialSet": {
+                              "type": "Microsoft.ContainerRegistry/registries/credentialSets",
+                              "apiVersion": "2025-11-01",
+                              "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                              "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), 'SystemAssigned', null())), null())]",
+                              "properties": {
+                                "authCredentials": "[parameters('authCredentials')]",
+                                "loginServer": "[parameters('loginServer')]"
+                              }
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The Name of the Credential Set."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the Credential Set."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the Credential Set."
+                              },
+                              "value": "[resourceId('Microsoft.ContainerRegistry/registries/credentialSets', parameters('registryName'), parameters('name'))]"
+                            },
+                            "systemAssignedMIPrincipalId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "The principal ID of the system assigned identity."
+                              },
+                              "value": "[tryGet(tryGet(reference('credentialSet', '2025-11-01', 'full'), 'identity'), 'principalId')]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_cacheRules": {
+                      "copy": {
+                        "name": "registry_cacheRules",
+                        "count": "[length(coalesce(parameters('cacheRules'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('{0}-Registry-Cache-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "registryName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "sourceRepository": {
+                            "value": "[coalesce(parameters('cacheRules'), createArray())[copyIndex()].sourceRepository]"
+                          },
+                          "name": {
+                            "value": "[tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'name')]"
+                          },
+                          "targetRepository": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'targetRepository'), coalesce(parameters('cacheRules'), createArray())[copyIndex()].sourceRepository)]"
+                          },
+                          "credentialSetResourceId": {
+                            "value": "[tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'credentialSetResourceId')]"
+                          },
+                          "enableTelemetry": {
+                            "value": "[variables('enableReferencedModulesTelemetry')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.42.1.51946",
+                              "templateHash": "1319901650921923538"
+                            },
+                            "name": "Container Registry Cache",
+                            "description": "The cache for Azure Container Registry (Preview) feature allows users to cache container images in a private container registry. Cache for ACR, is a preview feature available in Basic, Standard, and Premium service tiers ([ref](https://learn.microsoft.com/en-us/azure/container-registry/tutorial-registry-cache))."
+                          },
+                          "parameters": {
+                            "registryName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "defaultValue": "[replace(replace(replace(parameters('sourceRepository'), '/', '-'), '.', '-'), '*', '')]",
+                              "metadata": {
+                                "description": "Optional. The name of the cache rule. Will be derived from the source repository name if not defined."
+                              }
+                            },
+                            "sourceRepository": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. Source repository pulled from upstream."
+                              }
+                            },
+                            "targetRepository": {
+                              "type": "string",
+                              "defaultValue": "[parameters('sourceRepository')]",
+                              "metadata": {
+                                "description": "Optional. Target repository specified in docker pull command. E.g.: docker pull myregistry.azurecr.io/{targetRepository}:{tag}."
+                              }
+                            },
+                            "credentialSetResourceId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The resource ID of the credential store which is associated with the cache rule. Required only when pulling from authenticated upstream registries (e.g., Docker Hub). Omit for anonymous public registries such as MCR (mcr.microsoft.com)."
+                              }
+                            },
+                            "enableTelemetry": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Enable/Disable usage telemetry for module."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "avmTelemetry": {
+                              "condition": "[parameters('enableTelemetry')]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('46d3xbcp.res.containerregistry-registry-cacherule.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                              "properties": {
+                                "mode": "Incremental",
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "resources": [],
+                                  "outputs": {
+                                    "telemetry": {
+                                      "type": "String",
+                                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "registry": {
+                              "existing": true,
+                              "type": "Microsoft.ContainerRegistry/registries",
+                              "apiVersion": "2025-11-01",
+                              "name": "[parameters('registryName')]"
+                            },
+                            "cacheRule": {
+                              "type": "Microsoft.ContainerRegistry/registries/cacheRules",
+                              "apiVersion": "2025-11-01",
+                              "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                              "properties": {
+                                "sourceRepository": "[parameters('sourceRepository')]",
+                                "targetRepository": "[parameters('targetRepository')]",
+                                "credentialSetResourceId": "[parameters('credentialSetResourceId')]"
+                              }
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The Name of the Cache Rule."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the Cache Rule."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the Cache Rule."
+                              },
+                              "value": "[resourceId('Microsoft.ContainerRegistry/registries/cacheRules', parameters('registryName'), parameters('name'))]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "registry",
+                        "registry_credentialSets"
+                      ]
+                    },
+                    "registry_tokens": {
+                      "copy": {
+                        "name": "registry_tokens",
+                        "count": "[length(coalesce(parameters('tokens'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('{0}-Registry-Token-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[coalesce(parameters('tokens'), createArray())[copyIndex()].name]"
+                          },
+                          "registryName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "scopeMapResourceId": {
+                            "value": "[coalesce(parameters('tokens'), createArray())[copyIndex()].scopeMapResourceId]"
+                          },
+                          "status": {
+                            "value": "[tryGet(coalesce(parameters('tokens'), createArray())[copyIndex()], 'status')]"
+                          },
+                          "credentials": {
+                            "value": "[tryGet(coalesce(parameters('tokens'), createArray())[copyIndex()], 'credentials')]"
+                          },
+                          "enableTelemetry": {
+                            "value": "[variables('enableReferencedModulesTelemetry')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.42.1.51946",
+                              "templateHash": "5970335582661416899"
+                            },
+                            "name": "Container Registries Tokens",
+                            "description": "Deploys an Azure Container Registry (ACR) Token."
+                          },
+                          "parameters": {
+                            "registryName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "minLength": 5,
+                              "maxLength": 50,
+                              "metadata": {
+                                "description": "Required. The name of the token."
+                              }
+                            },
+                            "scopeMapResourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The resource ID of the scope map to which the token will be associated with."
+                              }
+                            },
+                            "status": {
+                              "type": "string",
+                              "defaultValue": "enabled",
+                              "allowedValues": [
+                                "disabled",
+                                "enabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The status of the token. Default is enabled."
+                              }
+                            },
+                            "credentials": {
+                              "type": "object",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.ContainerRegistry/registries/tokens@2025-11-01#properties/properties/properties/credentials"
+                                },
+                                "description": "Optional. The credentials associated with the token for authentication."
+                              },
+                              "nullable": true
+                            },
+                            "enableTelemetry": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Enable/Disable usage telemetry for module."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "avmTelemetry": {
+                              "condition": "[parameters('enableTelemetry')]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('46d3xbcp.res.containerregistry-registry-token.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                              "properties": {
+                                "mode": "Incremental",
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "resources": [],
+                                  "outputs": {
+                                    "telemetry": {
+                                      "type": "String",
+                                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "registry": {
+                              "existing": true,
+                              "type": "Microsoft.ContainerRegistry/registries",
+                              "apiVersion": "2025-11-01",
+                              "name": "[parameters('registryName')]"
+                            },
+                            "token": {
+                              "type": "Microsoft.ContainerRegistry/registries/tokens",
+                              "apiVersion": "2025-11-01",
+                              "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                              "properties": {
+                                "scopeMapId": "[parameters('scopeMapResourceId')]",
+                                "status": "[parameters('status')]",
+                                "credentials": "[if(not(empty(coalesce(parameters('credentials'), createArray()))), createObject('certificates', tryGet(parameters('credentials'), 'certificates'), 'passwords', tryGet(parameters('credentials'), 'passwords')), null())]"
+                              }
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the token."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the resource group the token was created in."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the token."
+                              },
+                              "value": "[resourceId('Microsoft.ContainerRegistry/registries/tokens', parameters('registryName'), parameters('name'))]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "registry",
+                        "registry_scopeMaps"
+                      ]
+                    },
+                    "registry_tasks": {
+                      "copy": {
+                        "name": "registry_tasks",
+                        "count": "[length(coalesce(parameters('tasks'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('{0}-Registry-Task-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "registryName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "name": {
+                            "value": "[coalesce(parameters('tasks'), createArray())[copyIndex()].name]"
+                          },
+                          "location": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'location'), parameters('location'))]"
+                          },
+                          "tags": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                          },
+                          "platform": {
+                            "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'platform')]"
+                          },
+                          "step": {
+                            "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'step')]"
+                          },
+                          "trigger": {
+                            "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'trigger')]"
+                          },
+                          "status": {
+                            "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'status')]"
+                          },
+                          "timeout": {
+                            "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'timeout')]"
+                          },
+                          "agentConfiguration": {
+                            "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'agentConfiguration')]"
+                          },
+                          "agentPoolName": {
+                            "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'agentPoolName')]"
+                          },
+                          "credentials": {
+                            "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'credentials')]"
+                          },
+                          "isSystemTask": {
+                            "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'isSystemTask')]"
+                          },
+                          "logTemplate": {
+                            "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'logTemplate')]"
+                          },
+                          "managedIdentities": {
+                            "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'managedIdentities')]"
+                          },
+                          "enableTelemetry": {
+                            "value": "[variables('enableReferencedModulesTelemetry')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.42.1.51946",
+                              "templateHash": "2468771835002458415"
+                            },
+                            "name": "Container Registries Tasks",
+                            "description": "Deploys an Azure Container Registry (ACR) Task that can be used to automate container image builds and other workflows ([ref](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-tasks-overview))."
+                          },
+                          "definitions": {
+                            "managedIdentityAllType": {
+                              "type": "object",
+                              "properties": {
+                                "systemAssigned": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Enables system assigned managed identity on the resource."
+                                  }
+                                },
+                                "userAssignedResourceIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The resource ID(s) to assign to the resource. Required if a user assigned identity is used for encryption."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                }
+                              }
+                            }
+                          },
+                          "parameters": {
+                            "registryName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "minLength": 5,
+                              "maxLength": 50,
+                              "metadata": {
+                                "description": "Required. The name of the task."
+                              }
+                            },
+                            "location": {
+                              "type": "string",
+                              "defaultValue": "[resourceGroup().location]",
+                              "metadata": {
+                                "description": "Optional. Location for all resources."
+                              }
+                            },
+                            "tags": {
+                              "type": "object",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/tags"
+                                },
+                                "description": "Optional. Tags of the resource."
+                              },
+                              "nullable": true
+                            },
+                            "platform": {
+                              "type": "object",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/platform"
+                                },
+                                "description": "Optional. The platform properties against which the task has to run."
+                              },
+                              "nullable": true
+                            },
+                            "step": {
+                              "type": "object",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/step"
+                                },
+                                "description": "Optional. The task step properties. Exactly one of dockerBuildStep, encodedTaskStep, or fileTaskStep must be provided."
+                              },
+                              "nullable": true
+                            },
+                            "trigger": {
+                              "type": "object",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/trigger"
+                                },
+                                "description": "Optional. The properties that describe all triggers for the task."
+                              },
+                              "nullable": true
+                            },
+                            "status": {
+                              "type": "string",
+                              "defaultValue": "Enabled",
+                              "allowedValues": [
+                                "Disabled",
+                                "Enabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The current status of task."
+                              }
+                            },
+                            "timeout": {
+                              "type": "int",
+                              "defaultValue": 3600,
+                              "minValue": 300,
+                              "maxValue": 28800,
+                              "metadata": {
+                                "description": "Optional. Run timeout in seconds."
+                              }
+                            },
+                            "agentConfiguration": {
+                              "type": "object",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/agentConfiguration"
+                                },
+                                "description": "Optional. The machine configuration of the run agent."
+                              },
+                              "nullable": true
+                            },
+                            "agentPoolName": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The dedicated agent pool for the task."
+                              }
+                            },
+                            "credentials": {
+                              "type": "object",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/credentials"
+                                },
+                                "description": "Optional. The properties that describe the credentials that will be used when the task is invoked."
+                              },
+                              "nullable": true
+                            },
+                            "isSystemTask": {
+                              "type": "bool",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The value of this property indicates whether the task resource is system task or not."
+                              }
+                            },
+                            "logTemplate": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The template that describes the repository and tag information for run log artifact."
+                              }
+                            },
+                            "managedIdentities": {
+                              "$ref": "#/definitions/managedIdentityAllType",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The managed identity definition for this resource."
+                              }
+                            },
+                            "enableTelemetry": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Enable/Disable usage telemetry for module."
+                              }
+                            }
+                          },
+                          "variables": {
+                            "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
+                            "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned, UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]"
+                          },
+                          "resources": {
+                            "avmTelemetry": {
+                              "condition": "[parameters('enableTelemetry')]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('46d3xbcp.res.containerregistry-registry-task.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                              "properties": {
+                                "mode": "Incremental",
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "resources": [],
+                                  "outputs": {
+                                    "telemetry": {
+                                      "type": "String",
+                                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "registry": {
+                              "existing": true,
+                              "type": "Microsoft.ContainerRegistry/registries",
+                              "apiVersion": "2025-11-01",
+                              "name": "[parameters('registryName')]"
+                            },
+                            "task": {
+                              "type": "Microsoft.ContainerRegistry/registries/tasks",
+                              "apiVersion": "2025-03-01-preview",
+                              "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                              "location": "[parameters('location')]",
+                              "identity": "[variables('identity')]",
+                              "tags": "[parameters('tags')]",
+                              "properties": {
+                                "agentConfiguration": "[parameters('agentConfiguration')]",
+                                "agentPoolName": "[parameters('agentPoolName')]",
+                                "credentials": "[parameters('credentials')]",
+                                "isSystemTask": "[parameters('isSystemTask')]",
+                                "logTemplate": "[parameters('logTemplate')]",
+                                "platform": "[parameters('platform')]",
+                                "status": "[parameters('status')]",
+                                "step": "[parameters('step')]",
+                                "timeout": "[parameters('timeout')]",
+                                "trigger": "[parameters('trigger')]"
+                              }
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the task."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the resource group the task was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the task."
+                              },
+                              "value": "[resourceId('Microsoft.ContainerRegistry/registries/tasks', parameters('registryName'), parameters('name'))]"
+                            },
+                            "location": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The location the resource was deployed into."
+                              },
+                              "value": "[reference('task', '2025-03-01-preview', 'full').location]"
+                            },
+                            "systemAssignedMIPrincipalId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "The principal ID of the system assigned identity."
+                              },
+                              "value": "[tryGet(tryGet(reference('task', '2025-03-01-preview', 'full'), 'identity'), 'principalId')]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_webhooks": {
+                      "copy": {
+                        "name": "registry_webhooks",
+                        "count": "[length(coalesce(parameters('webhooks'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('{0}-Registry-Webhook-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[coalesce(parameters('webhooks'), createArray())[copyIndex()].name]"
+                          },
+                          "registryName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "location": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'location'), parameters('location'))]"
+                          },
+                          "action": {
+                            "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'action')]"
+                          },
+                          "customHeaders": {
+                            "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'customHeaders')]"
+                          },
+                          "scope": {
+                            "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'scope')]"
+                          },
+                          "status": {
+                            "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'status')]"
+                          },
+                          "serviceUri": {
+                            "value": "[coalesce(parameters('webhooks'), createArray())[copyIndex()].serviceUri]"
+                          },
+                          "tags": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                          },
+                          "enableTelemetry": {
+                            "value": "[variables('enableReferencedModulesTelemetry')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.42.1.51946",
+                              "templateHash": "3200175097987099858"
+                            },
+                            "name": "Azure Container Registry (ACR) Webhooks",
+                            "description": "This module deploys an Azure Container Registry (ACR) Webhook."
+                          },
+                          "parameters": {
+                            "registryName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "defaultValue": "[format('{0}webhook', parameters('registryName'))]",
+                              "minLength": 5,
+                              "maxLength": 50,
+                              "metadata": {
+                                "description": "Optional. The name of the registry webhook."
+                              }
+                            },
+                            "serviceUri": {
+                              "type": "securestring",
+                              "metadata": {
+                                "description": "Required. The service URI for the webhook to post notifications."
+                              }
+                            },
+                            "status": {
+                              "type": "string",
+                              "defaultValue": "enabled",
+                              "allowedValues": [
+                                "disabled",
+                                "enabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The status of the webhook at the time the operation was called."
+                              }
+                            },
+                            "action": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "defaultValue": [
+                                "chart_delete",
+                                "chart_push",
+                                "delete",
+                                "push",
+                                "quarantine"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The list of actions that trigger the webhook to post notifications."
+                              }
+                            },
+                            "location": {
+                              "type": "string",
+                              "defaultValue": "[resourceGroup().location]",
+                              "metadata": {
+                                "description": "Optional. Location for all resources."
+                              }
+                            },
+                            "tags": {
+                              "type": "object",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.ContainerRegistry/registries/webhooks@2025-11-01#properties/tags"
+                                },
+                                "description": "Optional. Tags of the resource."
+                              },
+                              "nullable": true
+                            },
+                            "customHeaders": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Custom headers that will be added to the webhook notifications."
+                              }
+                            },
+                            "scope": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The scope of repositories where the event can be triggered. For example, 'foo:*' means events for all tags under repository 'foo'. 'foo:bar' means events for 'foo:bar' only. 'foo' is equivalent to 'foo:latest'. Empty means all events."
+                              }
+                            },
+                            "enableTelemetry": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Enable/Disable usage telemetry for module."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "avmTelemetry": {
+                              "condition": "[parameters('enableTelemetry')]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('46d3xbcp.res.containerregistry-registry-webhook.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                              "properties": {
+                                "mode": "Incremental",
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "resources": [],
+                                  "outputs": {
+                                    "telemetry": {
+                                      "type": "String",
+                                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "registry": {
+                              "existing": true,
+                              "type": "Microsoft.ContainerRegistry/registries",
+                              "apiVersion": "2025-11-01",
+                              "name": "[parameters('registryName')]"
+                            },
+                            "webhook": {
+                              "type": "Microsoft.ContainerRegistry/registries/webhooks",
+                              "apiVersion": "2025-11-01",
+                              "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                              "location": "[parameters('location')]",
+                              "tags": "[parameters('tags')]",
+                              "properties": {
+                                "actions": "[parameters('action')]",
+                                "customHeaders": "[parameters('customHeaders')]",
+                                "scope": "[parameters('scope')]",
+                                "serviceUri": "[parameters('serviceUri')]",
+                                "status": "[parameters('status')]"
+                              }
+                            }
+                          },
+                          "outputs": {
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the webhook."
+                              },
+                              "value": "[resourceId('Microsoft.ContainerRegistry/registries/webhooks', parameters('registryName'), parameters('name'))]"
+                            },
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the webhook."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the Azure container registry."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "actions": {
+                              "type": "array",
+                              "metadata": {
+                                "description": "The actions of the webhook."
+                              },
+                              "value": "[reference('webhook').actions]"
+                            },
+                            "status": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The status of the webhook."
+                              },
+                              "value": "[reference('webhook').status]"
+                            },
+                            "provistioningState": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The provisioning state of the webhook."
+                              },
+                              "value": "[reference('webhook').provisioningState]"
+                            },
+                            "location": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The location the resource was deployed into."
+                              },
+                              "value": "[reference('webhook', '2025-11-01', 'full').location]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_privateEndpoints": {
+                      "copy": {
+                        "name": "registry_privateEndpoints",
+                        "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[format('{0}-registry-PrivateEndpoint-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "subscriptionId": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[2]]",
+                      "resourceGroup": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[4]]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'name'), format('pep-{0}-{1}-{2}', last(split(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry'), copyIndex()))]"
+                          },
+                          "privateLinkServiceConnections": "[if(not(equals(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'isManualConnection'), true())), createObject('value', createArray(createObject('name', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateLinkServiceConnectionName'), format('{0}-{1}-{2}', last(split(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry'), copyIndex())), 'properties', createObject('privateLinkServiceId', resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), 'groupIds', createArray(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry')))))), createObject('value', null()))]",
+                          "manualPrivateLinkServiceConnections": "[if(equals(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'isManualConnection'), true()), createObject('value', createArray(createObject('name', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateLinkServiceConnectionName'), format('{0}-{1}-{2}', last(split(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry'), copyIndex())), 'properties', createObject('privateLinkServiceId', resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), 'groupIds', createArray(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry')), 'requestMessage', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'manualConnectionRequestMessage'), 'Manual approval required.'))))), createObject('value', null()))]",
+                          "subnetResourceId": {
+                            "value": "[coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId]"
+                          },
+                          "enableTelemetry": {
+                            "value": "[variables('enableReferencedModulesTelemetry')]"
+                          },
+                          "location": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'location'), reference(split(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location)]"
+                          },
+                          "lock": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'lock'), parameters('lock'))]"
+                          },
+                          "privateDnsZoneGroup": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateDnsZoneGroup')]"
+                          },
+                          "roleAssignments": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'roleAssignments')]"
+                          },
+                          "tags": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                          },
+                          "customDnsConfigs": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'customDnsConfigs')]"
+                          },
+                          "ipConfigurations": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'ipConfigurations')]"
+                          },
+                          "applicationSecurityGroupResourceIds": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'applicationSecurityGroupResourceIds')]"
+                          },
+                          "customNetworkInterfaceName": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'customNetworkInterfaceName')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.41.2.15936",
+                              "templateHash": "18436885663402767850"
+                            },
+                            "name": "Private Endpoints",
+                            "description": "This module deploys a Private Endpoint."
+                          },
+                          "definitions": {
+                            "privateDnsZoneGroupType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the Private DNS Zone Group."
+                                  }
+                                },
+                                "privateDnsZoneGroupConfigs": {
+                                  "type": "array",
+                                  "items": {
+                                    "$ref": "#/definitions/privateDnsZoneGroupConfigType"
+                                  },
+                                  "metadata": {
+                                    "description": "Required. The private DNS zone groups to associate the private endpoint. A DNS zone group can support up to 5 DNS zones."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "The type of a private dns zone group."
+                              }
+                            },
+                            "lockType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specify the name of lock."
+                                  }
+                                },
+                                "kind": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "CanNotDelete",
+                                    "None",
+                                    "ReadOnly"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specify the type of lock."
+                                  }
+                                },
+                                "notes": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specify the notes of the lock."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a lock.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                }
+                              }
+                            },
+                            "privateDnsZoneGroupConfigType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the private DNS zone group config."
+                                  }
+                                },
+                                "privateDnsZoneResourceId": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The resource id of the private DNS zone."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "The type of a private DNS zone group configuration.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "private-dns-zone-group/main.bicep"
+                                }
+                              }
+                            },
+                            "roleAssignmentType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                                  }
+                                },
+                                "roleDefinitionIdOrName": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                                  }
+                                },
+                                "principalId": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                                  }
+                                },
+                                "principalType": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "Device",
+                                    "ForeignGroup",
+                                    "Group",
+                                    "ServicePrincipal",
+                                    "User"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The principal type of the assigned principal ID."
+                                  }
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The description of the role assignment."
+                                  }
+                                },
+                                "condition": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                                  }
+                                },
+                                "conditionVersion": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "2.0"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Version of the condition."
+                                  }
+                                },
+                                "delegatedManagedIdentityResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a role assignment.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                }
+                              }
+                            }
+                          },
+                          "parameters": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. Name of the private endpoint resource to create."
+                              }
+                            },
+                            "subnetResourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                              }
+                            },
+                            "applicationSecurityGroupResourceIds": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Application security groups in which the private endpoint IP configuration is included."
+                              }
+                            },
+                            "customNetworkInterfaceName": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The custom name of the network interface attached to the private endpoint."
+                              }
+                            },
+                            "ipConfigurations": {
+                              "type": "array",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/ipConfigurations"
+                                },
+                                "description": "Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints."
+                              },
+                              "nullable": true
+                            },
+                            "ipVersionType": {
+                              "type": "string",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/ipVersionType"
+                                },
+                                "description": "Optional. Specifies the IP version type for the private IPs of the private endpoint. If not defined, this defaults to IPv4."
+                              },
+                              "defaultValue": "IPv4"
+                            },
+                            "privateDnsZoneGroup": {
+                              "$ref": "#/definitions/privateDnsZoneGroupType",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The private DNS zone group to configure for the private endpoint."
+                              }
+                            },
+                            "location": {
+                              "type": "string",
+                              "defaultValue": "[resourceGroup().location]",
+                              "metadata": {
+                                "description": "Optional. Location for all Resources."
+                              }
+                            },
+                            "lock": {
+                              "$ref": "#/definitions/lockType",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The lock settings of the service."
+                              }
+                            },
+                            "roleAssignments": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/roleAssignmentType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Array of role assignments to create."
+                              }
+                            },
+                            "tags": {
+                              "type": "object",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/tags"
+                                },
+                                "description": "Optional. Tags to be applied on all resources/resource groups in this deployment."
+                              },
+                              "nullable": true
+                            },
+                            "customDnsConfigs": {
+                              "type": "array",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/customDnsConfigs"
+                                },
+                                "description": "Optional. Custom DNS configurations."
+                              },
+                              "nullable": true
+                            },
+                            "manualPrivateLinkServiceConnections": {
+                              "type": "array",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/manualPrivateLinkServiceConnections"
+                                },
+                                "description": "Conditional. A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the remote resource. Required if `privateLinkServiceConnections` is empty."
+                              },
+                              "nullable": true
+                            },
+                            "privateLinkServiceConnections": {
+                              "type": "array",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/privateLinkServiceConnections"
+                                },
+                                "description": "Conditional. A grouping of information about the connection to the remote resource. Required if `manualPrivateLinkServiceConnections` is empty."
+                              },
+                              "nullable": true
+                            },
+                            "enableTelemetry": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Enable/Disable usage telemetry for module."
+                              }
+                            }
+                          },
+                          "variables": {
+                            "copy": [
+                              {
+                                "name": "formattedRoleAssignments",
+                                "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                                "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                              }
+                            ],
+                            "builtInRoleNames": {
+                              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                              "DNS Resolver Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f2ebee7-ffd4-4fc0-b3b7-664099fdad5d')]",
+                              "DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314')]",
+                              "Domain Services Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'eeaeda52-9324-47f6-8069-5d5bade478b2')]",
+                              "Domain Services Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '361898ef-9ed1-48c2-849c-a832951106bb')]",
+                              "Network Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
+                              "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                              "Private DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b12aa53e-6015-4669-85d0-8515ebb3ae7f')]",
+                              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
+                            }
+                          },
+                          "resources": {
+                            "avmTelemetry": {
+                              "condition": "[parameters('enableTelemetry')]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.12.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                              "properties": {
+                                "mode": "Incremental",
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "resources": [],
+                                  "outputs": {
+                                    "telemetry": {
+                                      "type": "String",
+                                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "privateEndpoint": {
+                              "type": "Microsoft.Network/privateEndpoints",
+                              "apiVersion": "2025-05-01",
+                              "name": "[parameters('name')]",
+                              "location": "[parameters('location')]",
+                              "tags": "[parameters('tags')]",
+                              "properties": {
+                                "copy": [
+                                  {
+                                    "name": "applicationSecurityGroups",
+                                    "count": "[length(coalesce(parameters('applicationSecurityGroupResourceIds'), createArray()))]",
+                                    "input": {
+                                      "id": "[coalesce(parameters('applicationSecurityGroupResourceIds'), createArray())[copyIndex('applicationSecurityGroups')]]"
+                                    }
+                                  }
+                                ],
+                                "customDnsConfigs": "[coalesce(parameters('customDnsConfigs'), createArray())]",
+                                "customNetworkInterfaceName": "[coalesce(parameters('customNetworkInterfaceName'), '')]",
+                                "ipConfigurations": "[coalesce(parameters('ipConfigurations'), createArray())]",
+                                "manualPrivateLinkServiceConnections": "[coalesce(parameters('manualPrivateLinkServiceConnections'), createArray())]",
+                                "privateLinkServiceConnections": "[coalesce(parameters('privateLinkServiceConnections'), createArray())]",
+                                "subnet": {
+                                  "id": "[parameters('subnetResourceId')]"
+                                },
+                                "ipVersionType": "[parameters('ipVersionType')]"
+                              }
+                            },
+                            "privateEndpoint_lock": {
+                              "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                              "type": "Microsoft.Authorization/locks",
+                              "apiVersion": "2020-05-01",
+                              "scope": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]",
+                              "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                              "properties": {
+                                "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                                "notes": "[coalesce(tryGet(parameters('lock'), 'notes'), if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.'))]"
+                              },
+                              "dependsOn": [
+                                "privateEndpoint"
+                              ]
+                            },
+                            "privateEndpoint_roleAssignments": {
+                              "copy": {
+                                "name": "privateEndpoint_roleAssignments",
+                                "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                              },
+                              "type": "Microsoft.Authorization/roleAssignments",
+                              "apiVersion": "2022-04-01",
+                              "scope": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]",
+                              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Network/privateEndpoints', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                              "properties": {
+                                "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                                "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                                "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                                "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                                "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                                "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                                "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                              },
+                              "dependsOn": [
+                                "privateEndpoint"
+                              ]
+                            },
+                            "privateEndpoint_privateDnsZoneGroup": {
+                              "condition": "[not(empty(parameters('privateDnsZoneGroup')))]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('{0}-PrivateEndpoint-PrivateDnsZoneGroup', uniqueString(deployment().name))]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "name": {
+                                    "value": "[tryGet(parameters('privateDnsZoneGroup'), 'name')]"
+                                  },
+                                  "privateEndpointName": {
+                                    "value": "[parameters('name')]"
+                                  },
+                                  "privateDnsZoneConfigs": {
+                                    "value": "[parameters('privateDnsZoneGroup').privateDnsZoneGroupConfigs]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.0",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.41.2.15936",
+                                      "templateHash": "9935179114830442414"
+                                    },
+                                    "name": "Private Endpoint Private DNS Zone Groups",
+                                    "description": "This module deploys a Private Endpoint Private DNS Zone Group."
+                                  },
+                                  "definitions": {
+                                    "privateDnsZoneGroupConfigType": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. The name of the private DNS zone group config."
+                                          }
+                                        },
+                                        "privateDnsZoneResourceId": {
+                                          "type": "string",
+                                          "metadata": {
+                                            "description": "Required. The resource id of the private DNS zone."
+                                          }
+                                        }
+                                      },
+                                      "metadata": {
+                                        "__bicep_export!": true,
+                                        "description": "The type of a private DNS zone group configuration."
+                                      }
+                                    }
+                                  },
+                                  "parameters": {
+                                    "privateEndpointName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent private endpoint. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "privateDnsZoneConfigs": {
+                                      "type": "array",
+                                      "items": {
+                                        "$ref": "#/definitions/privateDnsZoneGroupConfigType"
+                                      },
+                                      "minLength": 1,
+                                      "maxLength": 5,
+                                      "metadata": {
+                                        "description": "Required. Array of private DNS zone configurations of the private DNS zone group. A DNS zone group can support up to 5 DNS zones."
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "defaultValue": "default",
+                                      "metadata": {
+                                        "description": "Optional. The name of the private DNS zone group."
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "privateEndpoint": {
+                                      "existing": true,
+                                      "type": "Microsoft.Network/privateEndpoints",
+                                      "apiVersion": "2025-05-01",
+                                      "name": "[parameters('privateEndpointName')]"
+                                    },
+                                    "privateDnsZoneGroup": {
+                                      "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                                      "apiVersion": "2025-05-01",
+                                      "name": "[format('{0}/{1}', parameters('privateEndpointName'), parameters('name'))]",
+                                      "properties": {
+                                        "copy": [
+                                          {
+                                            "name": "privateDnsZoneConfigs",
+                                            "count": "[length(parameters('privateDnsZoneConfigs'))]",
+                                            "input": {
+                                              "name": "[coalesce(tryGet(parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigs')], 'name'), last(split(parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigs')].privateDnsZoneResourceId, '/')))]",
+                                              "properties": {
+                                                "privateDnsZoneId": "[parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigs')].privateDnsZoneResourceId]"
+                                              }
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "outputs": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the private endpoint DNS zone group."
+                                      },
+                                      "value": "[parameters('name')]"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the private endpoint DNS zone group."
+                                      },
+                                      "value": "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', parameters('privateEndpointName'), parameters('name'))]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource group the private endpoint DNS zone group was deployed into."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "privateEndpoint"
+                              ]
+                            }
+                          },
+                          "outputs": {
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource group the private endpoint was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the private endpoint."
+                              },
+                              "value": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]"
+                            },
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the private endpoint."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "location": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The location the resource was deployed into."
+                              },
+                              "value": "[reference('privateEndpoint', '2025-05-01', 'full').location]"
+                            },
+                            "customDnsConfigs": {
+                              "type": "array",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/customDnsConfigs",
+                                  "output": true
+                                },
+                                "description": "The custom DNS configurations of the private endpoint."
+                              },
+                              "value": "[reference('privateEndpoint').customDnsConfigs]"
+                            },
+                            "networkInterfaceResourceIds": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "description": "The resource IDs of the network interfaces associated with the private endpoint."
+                              },
+                              "value": "[map(reference('privateEndpoint').networkInterfaces, lambda('nic', lambdaVariables('nic').id))]"
+                            },
+                            "groupId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "The group Id for the private endpoint Group."
+                              },
+                              "value": "[coalesce(tryGet(tryGet(tryGet(tryGet(reference('privateEndpoint'), 'manualPrivateLinkServiceConnections'), 0, 'properties'), 'groupIds'), 0), tryGet(tryGet(tryGet(tryGet(reference('privateEndpoint'), 'privateLinkServiceConnections'), 0, 'properties'), 'groupIds'), 0))]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "registry",
+                        "registry_replications"
+                      ]
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The Name of the Azure container registry."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "loginServer": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The reference to the Azure container registry."
+                      },
+                      "value": "[reference('registry').loginServer]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the Azure container registry."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the Azure container registry."
+                      },
+                      "value": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]"
+                    },
+                    "systemAssignedMIPrincipalId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "The principal ID of the system assigned identity."
+                      },
+                      "value": "[tryGet(tryGet(reference('registry', '2025-06-01-preview', 'full'), 'identity'), 'principalId')]"
+                    },
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The location the resource was deployed into."
+                      },
+                      "value": "[reference('registry', '2025-06-01-preview', 'full').location]"
+                    },
+                    "credentialSetsSystemAssignedMIPrincipalIds": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "The Principal IDs of the ACR Credential Sets system-assigned identities."
+                      },
+                      "copy": {
+                        "count": "[length(range(0, length(coalesce(parameters('credentialSets'), createArray()))))]",
+                        "input": "[tryGet(tryGet(reference(format('registry_credentialSets[{0}]', range(0, length(coalesce(parameters('credentialSets'), createArray())))[copyIndex()])).outputs, 'systemAssignedMIPrincipalId'), 'value')]"
+                      }
+                    },
+                    "credentialSetsResourceIds": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "The Resource IDs of the ACR Credential Sets."
+                      },
+                      "copy": {
+                        "count": "[length(range(0, length(coalesce(parameters('credentialSets'), createArray()))))]",
+                        "input": "[reference(format('registry_credentialSets[{0}]', range(0, length(coalesce(parameters('credentialSets'), createArray())))[copyIndex()])).outputs.resourceId.value]"
+                      }
+                    },
+                    "privateEndpoints": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/privateEndpointOutputType"
+                      },
+                      "metadata": {
+                        "description": "The private endpoints of the Azure container registry."
+                      },
+                      "copy": {
+                        "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]",
+                        "input": {
+                          "name": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.name.value]",
+                          "resourceId": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.resourceId.value]",
+                          "groupId": "[tryGet(tryGet(reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs, 'groupId'), 'value')]",
+                          "customDnsConfigs": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.customDnsConfigs.value]",
+                          "networkInterfaceResourceIds": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.networkInterfaceResourceIds.value]"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the container registry."
+              },
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', take(format('avm.res.containerregistry.{0}', parameters('name')), 64)), '2025-04-01').outputs.name.value]"
+            },
+            "loginServer": {
+              "type": "string",
+              "metadata": {
+                "description": "The login server URL."
+              },
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', take(format('avm.res.containerregistry.{0}', parameters('name')), 64)), '2025-04-01').outputs.loginServer.value]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the container registry."
+              },
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', take(format('avm.res.containerregistry.{0}', parameters('name')), 64)), '2025-04-01').outputs.resourceId.value]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').containerRegistry)]",
+        "virtualNetwork"
+      ]
+    },
     "hostingplan": {
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
@@ -46665,7 +50771,10 @@
             "value": "[reference('hostingplan').outputs.resourceId.value]"
           },
           "linuxFxVersion": {
-            "value": "[format('DOCKER|{0}.azurecr.io/da-api:{1}', parameters('containerRegistryName'), parameters('imageTag'))]"
+            "value": "[variables('placeholderContainerImage')]"
+          },
+          "acrUseManagedIdentityCreds": {
+            "value": true
           },
           "virtualNetworkSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.webserverfarmSubnetResourceId.value), createObject('value', ''))]",
           "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
@@ -46719,7 +50828,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "7219841793741923362"
+              "templateHash": "15548497476269761773"
             }
           },
           "definitions": {
@@ -47231,6 +51340,13 @@
                 "description": "Optional. Whether to route content share traffic through the virtual network."
               }
             },
+            "acrUseManagedIdentityCreds": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Use the app managed identity to authenticate ACR image pulls."
+              }
+            },
             "privateEndpoints": {
               "type": "array",
               "items": {
@@ -47326,7 +51442,8 @@
                       "healthCheckPath": "[if(not(empty(parameters('healthCheckPath'))), parameters('healthCheckPath'), null())]",
                       "webSocketsEnabled": "[parameters('webSocketsEnabled')]",
                       "appCommandLine": "[parameters('appCommandLine')]",
-                      "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]"
+                      "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]",
+                      "acrUseManagedIdentityCreds": "[parameters('acrUseManagedIdentityCreds')]"
                     }
                   },
                   "e2eEncryptionEnabled": {
@@ -62238,7 +66355,10 @@
             "value": "[reference('hostingplan').outputs.resourceId.value]"
           },
           "linuxFxVersion": {
-            "value": "[format('DOCKER|{0}.azurecr.io/da-api-dotnet:{1}', parameters('containerRegistryName'), parameters('imageTag'))]"
+            "value": "[variables('placeholderContainerImage')]"
+          },
+          "acrUseManagedIdentityCreds": {
+            "value": true
           },
           "virtualNetworkSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.webserverfarmSubnetResourceId.value), createObject('value', ''))]",
           "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
@@ -62288,7 +66408,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "7219841793741923362"
+              "templateHash": "15548497476269761773"
             }
           },
           "definitions": {
@@ -62800,6 +66920,13 @@
                 "description": "Optional. Whether to route content share traffic through the virtual network."
               }
             },
+            "acrUseManagedIdentityCreds": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Use the app managed identity to authenticate ACR image pulls."
+              }
+            },
             "privateEndpoints": {
               "type": "array",
               "items": {
@@ -62895,7 +67022,8 @@
                       "healthCheckPath": "[if(not(empty(parameters('healthCheckPath'))), parameters('healthCheckPath'), null())]",
                       "webSocketsEnabled": "[parameters('webSocketsEnabled')]",
                       "appCommandLine": "[parameters('appCommandLine')]",
-                      "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]"
+                      "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]",
+                      "acrUseManagedIdentityCreds": "[parameters('acrUseManagedIdentityCreds')]"
                     }
                   },
                   "e2eEncryptionEnabled": {
@@ -77806,7 +81934,10 @@
             "value": "[reference('hostingplan').outputs.resourceId.value]"
           },
           "linuxFxVersion": {
-            "value": "[format('DOCKER|{0}.azurecr.io/da-app:{1}', parameters('containerRegistryName'), parameters('imageTag'))]"
+            "value": "[variables('placeholderContainerImage')]"
+          },
+          "acrUseManagedIdentityCreds": {
+            "value": true
           },
           "virtualNetworkSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.webserverfarmSubnetResourceId.value), createObject('value', ''))]",
           "publicNetworkAccess": {
@@ -77832,7 +81963,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "7219841793741923362"
+              "templateHash": "15548497476269761773"
             }
           },
           "definitions": {
@@ -78344,6 +82475,13 @@
                 "description": "Optional. Whether to route content share traffic through the virtual network."
               }
             },
+            "acrUseManagedIdentityCreds": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Use the app managed identity to authenticate ACR image pulls."
+              }
+            },
             "privateEndpoints": {
               "type": "array",
               "items": {
@@ -78439,7 +82577,8 @@
                       "healthCheckPath": "[if(not(empty(parameters('healthCheckPath'))), parameters('healthCheckPath'), null())]",
                       "webSocketsEnabled": "[parameters('webSocketsEnabled')]",
                       "appCommandLine": "[parameters('appCommandLine')]",
-                      "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]"
+                      "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]",
+                      "acrUseManagedIdentityCreds": "[parameters('acrUseManagedIdentityCreds')]"
                     }
                   },
                   "e2eEncryptionEnabled": {
@@ -93346,6 +97485,12 @@
             "value": "[reference('cosmosDBModule').outputs.name.value]"
           },
           "backendAppServicePrincipalId": "[if(equals(parameters('backendRuntimeStack'), 'python'), createObject('value', reference('backend_docker').outputs.identityPrincipalId.value), createObject('value', reference('backend_csapi_docker').outputs.identityPrincipalId.value))]",
+          "frontendAppServicePrincipalId": {
+            "value": "[reference('frontend_docker').outputs.identityPrincipalId.value]"
+          },
+          "containerRegistryResourceId": {
+            "value": "[reference('containerRegistry').outputs.resourceId.value]"
+          },
           "aiFoundryResourceId": "[if(variables('useExistingAIProject'), createObject('value', reference('existing_project_setup').outputs.resourceId.value), createObject('value', reference('ai_foundry_project').outputs.resourceId.value))]",
           "useExistingAIProject": {
             "value": "[variables('useExistingAIProject')]"
@@ -93361,7 +97506,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "15652761467149754710"
+              "templateHash": "1138212285559024015"
             }
           },
           "parameters": {
@@ -93407,6 +97552,13 @@
                 "description": "Principal ID of the backend App Service system-assigned identity (empty if not deployed)."
               }
             },
+            "frontendAppServicePrincipalId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Principal ID of the frontend App Service system-assigned identity (empty if not deployed)."
+              }
+            },
             "aiFoundryResourceId": {
               "type": "string",
               "defaultValue": "",
@@ -93434,6 +97586,13 @@
               "metadata": {
                 "description": "Name of the Cosmos DB account (empty if not deployed)."
               }
+            },
+            "containerRegistryResourceId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Resource ID of the Azure Container Registry (empty if not deployed)."
+              }
             }
           },
           "variables": {
@@ -93447,7 +97606,8 @@
               "searchIndexDataReader": "1407120a-92aa-4202-b7e9-c0e197c71c8f",
               "searchServiceContributor": "7ca78c08-252a-4471-8644-bb5ff32d4ba0",
               "storageBlobDataContributor": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
-              "storageBlobDataReader": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1"
+              "storageBlobDataReader": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
+              "acrPull": "7f951dda-4ed3-4680-a7ca-43fe172d538d"
             }
           },
           "resources": [
@@ -93556,6 +97716,30 @@
                 "principalId": "[parameters('backendAppServicePrincipalId')]",
                 "roleDefinitionId": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', parameters('cosmosDbAccountName'), '00000000-0000-0000-0000-000000000002')]",
                 "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosDbAccountName'))]"
+              }
+            },
+            {
+              "condition": "[and(not(empty(parameters('containerRegistryResourceId'))), not(empty(parameters('backendAppServicePrincipalId'))))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/')))]",
+              "name": "[guid(parameters('solutionName'), resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/'))), parameters('backendAppServicePrincipalId'), variables('roleDefinitions').acrPull)]",
+              "properties": {
+                "principalId": "[parameters('backendAppServicePrincipalId')]",
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefinitions').acrPull)]",
+                "principalType": "ServicePrincipal"
+              }
+            },
+            {
+              "condition": "[and(not(empty(parameters('containerRegistryResourceId'))), not(empty(parameters('frontendAppServicePrincipalId'))))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/')))]",
+              "name": "[guid(parameters('solutionName'), resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/'))), parameters('frontendAppServicePrincipalId'), variables('roleDefinitions').acrPull)]",
+              "properties": {
+                "principalId": "[parameters('frontendAppServicePrincipalId')]",
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefinitions').acrPull)]",
+                "principalType": "ServicePrincipal"
               }
             },
             {
@@ -93744,8 +97928,10 @@
         "ai_search",
         "backend_csapi_docker",
         "backend_docker",
+        "containerRegistry",
         "cosmosDBModule",
         "existing_project_setup",
+        "frontend_docker",
         "storage_account"
       ]
     }
@@ -93771,6 +97957,27 @@
         "description": "WAF deployment type."
       },
       "value": "[if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF')]"
+    },
+    "AZURE_ENV_CONTAINER_REGISTRY_NAME": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the dedicated Azure Container Registry."
+      },
+      "value": "[reference('containerRegistry').outputs.name.value]"
+    },
+    "AZURE_CONTAINER_REGISTRY_ENDPOINT": {
+      "type": "string",
+      "metadata": {
+        "description": "Login server of the dedicated Azure Container Registry."
+      },
+      "value": "[reference('containerRegistry').outputs.loginServer.value]"
+    },
+    "AZURE_ENV_IMAGE_TAG": {
+      "type": "string",
+      "metadata": {
+        "description": "Docker image tag used for app deployments."
+      },
+      "value": "[parameters('imageTag')]"
     },
     "AZURE_COSMOSDB_ACCOUNT": {
       "type": "string",

--- a/infra/avm/modules/compute/app-service.bicep
+++ b/infra/avm/modules/compute/app-service.bicep
@@ -78,6 +78,9 @@ param imagePullTraffic bool = false
 @description('Optional. Whether to route content share traffic through the virtual network.')
 param contentShareTraffic bool = false
 
+@description('Optional. Use the app managed identity to authenticate ACR image pulls.')
+param acrUseManagedIdentityCreds bool = false
+
 import { privateEndpointSingleServiceType } from 'br/public:avm/utl/types/avm-common-types:0.5.1'
 @description('Optional. Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible.')
 param privateEndpoints privateEndpointSingleServiceType[]?
@@ -107,6 +110,7 @@ module appService 'br/public:avm/res/web/site:0.23.1' = {
       webSocketsEnabled: webSocketsEnabled
       appCommandLine: appCommandLine
       vnetRouteAllEnabled: vnetRouteAllEnabled
+      acrUseManagedIdentityCreds: acrUseManagedIdentityCreds
     }
     e2eEncryptionEnabled: true
     configs: [

--- a/infra/avm/modules/compute/container-registry.bicep
+++ b/infra/avm/modules/compute/container-registry.bicep
@@ -29,6 +29,10 @@ param publicNetworkAccess string = 'Enabled'
 @description('Export policy status. Must be "enabled" when publicNetworkAccess is "Enabled".')
 param exportPolicyStatus string = 'enabled'
 
+@description('Enable the ARM-audience AAD token policy. Must be "enabled" for App Service managed-identity image pulls to work (the AVM module defaults this to "disabled", which causes ACR token retrieval to fail with 401).')
+@allowed(['enabled', 'disabled'])
+param azureADAuthenticationAsArmPolicyStatus string = 'enabled'
+
 @description('Principal IDs to assign AcrPull role.')
 param acrPullPrincipalIds array = []
 
@@ -113,6 +117,7 @@ module containerRegistry 'br/public:avm/res/container-registry/registry:0.12.1' 
     acrAdminUserEnabled: adminUserEnabled
     publicNetworkAccess: publicNetworkAccess
     exportPolicyStatus: exportPolicyStatus
+    azureADAuthenticationAsArmPolicyStatus: azureADAuthenticationAsArmPolicyStatus
     roleAssignments: !empty(roleAssignments) ? roleAssignments : []
     privateEndpoints: privateEndpointConfig
     networkRuleSetDefaultAction: networkRuleSetDefaultAction

--- a/infra/avm/modules/identity/role-assignments.bicep
+++ b/infra/avm/modules/identity/role-assignments.bicep
@@ -28,6 +28,9 @@ param aiSearchPrincipalId string = ''
 @description('Principal ID of the backend App Service system-assigned identity (empty if not deployed).')
 param backendAppServicePrincipalId string = ''
 
+@description('Principal ID of the frontend App Service system-assigned identity (empty if not deployed).')
+param frontendAppServicePrincipalId string = ''
+
 // --- Resource References ---
 
 @description('Resource ID of the AI Foundry account (empty if not deployed — new project path).')
@@ -41,6 +44,9 @@ param storageAccountResourceId string = ''
 
 @description('Name of the Cosmos DB account (empty if not deployed).')
 param cosmosDbAccountName string = ''
+
+@description('Resource ID of the Azure Container Registry (empty if not deployed).')
+param containerRegistryResourceId string = ''
 
 // ============================================================================
 // Derived Variables
@@ -62,6 +68,7 @@ var roleDefinitions = {
   searchServiceContributor: '7ca78c08-252a-4471-8644-bb5ff32d4ba0'
   storageBlobDataContributor: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
   storageBlobDataReader: '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
+  acrPull: '7f951dda-4ed3-4680-a7ca-43fe172d538d'
 }
 
 // ============================================================================
@@ -82,6 +89,10 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2025-08-01' existing 
 
 resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2025-10-15' existing = if (!empty(cosmosDbAccountName)) {
   name: cosmosDbAccountName
+}
+
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = if (!empty(containerRegistryResourceId)) {
+  name: last(split(containerRegistryResourceId, '/'))
 }
 
 resource cosmosContributorRoleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions@2025-10-15' existing = if (!empty(cosmosDbAccountName)) {
@@ -230,4 +241,30 @@ resource backendAppCosmosRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/s
     scope: cosmosAccount.id
   }
 }
+
+// ============================================================================
+// 5. CONTAINER REGISTRY ROLE ASSIGNMENTS
+//    Backend + Frontend App Service identities → AcrPull on the dedicated ACR
+// ============================================================================
+
+resource backendAppAcrPullAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(containerRegistryResourceId) && !empty(backendAppServicePrincipalId)) {
+  name: guid(solutionName, containerRegistry.id, backendAppServicePrincipalId, roleDefinitions.acrPull)
+  scope: containerRegistry
+  properties: {
+    principalId: backendAppServicePrincipalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleDefinitions.acrPull)
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource frontendAppAcrPullAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(containerRegistryResourceId) && !empty(frontendAppServicePrincipalId)) {
+  name: guid(solutionName, containerRegistry.id, frontendAppServicePrincipalId, roleDefinitions.acrPull)
+  scope: containerRegistry
+  properties: {
+    principalId: frontendAppServicePrincipalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleDefinitions.acrPull)
+    principalType: 'ServicePrincipal'
+  }
+}
+
 

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -92,8 +92,8 @@ param azureAiAgentApiVersion string = '2025-05-01'
 @description('Optional. Docker image tag for app deployments.')
 param imageTag string = 'latest_v2'
 
-@description('Optional. Name of the Azure Container Registry.')
-param containerRegistryName string = 'dataagentscontainerreg'
+@description('Optional. Name of the Azure Container Registry. Empty derives a per-deployment name (cr<suffix>).')
+param containerRegistryName string = ''
 
 @allowed([
   'python'
@@ -189,6 +189,9 @@ var solutionSuffix = toLower(trim(replace(
 
 var deployerInfo = deployer()
 var deployingUserPrincipalId = deployerInfo.objectId
+
+// Container Registry: per-deployment ACR name (registry names: alphanumeric, 5-50 chars)
+var containerRegistryResourceName = !empty(containerRegistryName) ? containerRegistryName : take('cr${solutionSuffix}', 50)
 var createdBy = contains(deployerInfo, 'userPrincipalName') ? split(deployerInfo.userPrincipalName, '@')[0] : deployerInfo.objectId
 var existingTags = resourceGroup().tags ?? {}
 
@@ -450,12 +453,30 @@ module hostingplan './modules/compute/app-service-plan.bicep' = {
   }
 }
 
+// Seed / placeholder handling: App Services start on a public placeholder image;
+// the separate post-deployment script (infra/scripts/build/build-and-push-acr.*)
+// builds the real images into the dedicated ACR and repoints the apps.
+module containerRegistry './modules/compute/container-registry.bicep' = {
+  name: take('module.container-registry.${solutionName}', 64)
+  params: {
+    solutionName: solutionSuffix
+    name: containerRegistryResourceName
+    location: location
+    tags: existingTags
+    sku: 'Standard'
+    publicNetworkAccess: 'Enabled'
+  }
+  scope: resourceGroup(resourceGroup().name)
+}
+
 // ============================================================================
 // Module: Compute
 // ============================================================================
-var backendApiImageName = 'DOCKER|${containerRegistryName}.azurecr.io/da-api:${imageTag}'
-var backendCsApiImageName = 'DOCKER|${containerRegistryName}.azurecr.io/da-api-dotnet:${imageTag}'
-var frontendImageName = 'DOCKER|${containerRegistryName}.azurecr.io/da-app:${imageTag}'
+// Public placeholder image used at provision time (real images pushed post-deploy).
+var placeholderContainerImage = 'DOCKER|mcr.microsoft.com/azuredocs/aci-helloworld:latest'
+var backendApiImageName = placeholderContainerImage
+var backendCsApiImageName = placeholderContainerImage
+var frontendImageName = placeholderContainerImage
 var reactAppLayoutConfig = '''{
   "appConfig": {
       "CHAT_CHATHISTORY": {
@@ -475,6 +496,7 @@ module backend_docker './modules/compute/app-service.bicep' = if (backendRuntime
     location: location
     serverFarmResourceId: hostingplan!.outputs.resourceId
     linuxFxVersion: backendApiImageName
+    acrUseManagedIdentityCreds: true
     appSettings: {
       APPINSIGHTS_INSTRUMENTATIONKEY: app_insights.outputs.instrumentationKey
       REACT_APP_LAYOUT_CONFIG: reactAppLayoutConfig
@@ -528,6 +550,7 @@ module backend_csapi_docker './modules/compute/app-service.bicep' = if (backendR
     location: location
     serverFarmResourceId: hostingplan!.outputs.resourceId
     linuxFxVersion: backendCsApiImageName
+    acrUseManagedIdentityCreds: true
     appSettings: {
       APPINSIGHTS_INSTRUMENTATIONKEY: app_insights.outputs.instrumentationKey
       REACT_APP_LAYOUT_CONFIG: reactAppLayoutConfig
@@ -578,6 +601,7 @@ module frontend_docker './modules/compute/app-service.bicep' = {
     location: location
     serverFarmResourceId: hostingplan!.outputs.resourceId
     linuxFxVersion: frontendImageName
+    acrUseManagedIdentityCreds: true
     appSettings: {
       APPINSIGHTS_INSTRUMENTATIONKEY: app_insights.outputs.instrumentationKey
       APP_API_BASE_URL: apiBaseUrl
@@ -607,6 +631,8 @@ module role_assignments './modules/identity/role-assignments.bicep' = {
     deployerPrincipalId: deployingUserPrincipalId
     deployerPrincipalType: deployingUserPrincipalType
     backendAppServicePrincipalId: backendRuntimeStack == 'python' ? backend_docker!.outputs.identityPrincipalId : backend_csapi_docker!.outputs.identityPrincipalId
+    frontendAppServicePrincipalId: frontend_docker.outputs.identityPrincipalId
+    containerRegistryResourceId: containerRegistry.outputs.resourceId
     cosmosDbAccountName: cosmosDBModule.outputs.name
   }
   scope: resourceGroup(resourceGroup().name)
@@ -618,6 +644,15 @@ module role_assignments './modules/identity/role-assignments.bicep' = {
 
 @description('Solution suffix used for naming resources')
 output SOLUTION_NAME string = solutionSuffix
+
+@description('Name of the dedicated Azure Container Registry.')
+output AZURE_ENV_CONTAINER_REGISTRY_NAME string = containerRegistry.outputs.name
+
+@description('Login server of the dedicated Azure Container Registry.')
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.outputs.loginServer
+
+@description('Docker image tag used for app deployments.')
+output AZURE_ENV_IMAGE_TAG string = imageTag
 
 @description('Name of the deployed resource group')
 output RESOURCE_GROUP_NAME string = resourceGroup().name

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -40,7 +40,7 @@ param tags object = {}
   azd: {
     type: 'location'
     usageName: [
-      'OpenAI.GlobalStandard.gpt4.1-mini,100'
+      'OpenAI.GlobalStandard.gpt-5.4-mini,100'
       'OpenAI.GlobalStandard.text-embedding-3-small,80'
     ]
   }
@@ -60,10 +60,10 @@ param azureAiServiceLocation string
 param deploymentType string = 'GlobalStandard'
 
 @description('Optional. Name of the GPT model to deploy.')
-param gptModelName string = 'gpt-4.1-mini'
+param gptModelName string = 'gpt-5.4-mini'
 
 @description('Optional. Version of the GPT model to deploy.')
-param gptModelVersion string = '2025-04-14'
+param gptModelVersion string = '2026-03-17'
 
 @minValue(10)
 @description('Optional. Capacity of the GPT deployment (TPM in thousands).')

--- a/infra/bicep/main.json
+++ b/infra/bicep/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "15841029785825128032"
+      "templateHash": "15646615221951775073"
     }
   },
   "parameters": {
@@ -57,7 +57,7 @@
         "azd": {
           "type": "location",
           "usageName": [
-            "OpenAI.GlobalStandard.gpt4.1-mini,100",
+            "OpenAI.GlobalStandard.gpt-5.4-mini,100",
             "OpenAI.GlobalStandard.text-embedding-3-small,80"
           ]
         },
@@ -77,14 +77,14 @@
     },
     "gptModelName": {
       "type": "string",
-      "defaultValue": "gpt-4.1-mini",
+      "defaultValue": "gpt-5.4-mini",
       "metadata": {
         "description": "Optional. Name of the GPT model to deploy."
       }
     },
     "gptModelVersion": {
       "type": "string",
-      "defaultValue": "2025-04-14",
+      "defaultValue": "2026-03-17",
       "metadata": {
         "description": "Optional. Version of the GPT model to deploy."
       }

--- a/infra/bicep/main.json
+++ b/infra/bicep/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "4272848169429759010"
+      "templateHash": "15841029785825128032"
     }
   },
   "parameters": {
@@ -138,9 +138,9 @@
     },
     "containerRegistryName": {
       "type": "string",
-      "defaultValue": "dataagentscontainerreg",
+      "defaultValue": "",
       "metadata": {
-        "description": "Optional. Name of the Azure Container Registry."
+        "description": "Optional. Name of the Azure Container Registry. Empty derives a per-deployment name (cr<suffix>)."
       }
     },
     "backendRuntimeStack": {
@@ -275,6 +275,7 @@
     "solutionSuffix": "[toLower(trim(replace(replace(replace(replace(replace(replace(format('{0}{1}', parameters('solutionName'), parameters('solutionUniqueText')), '-', ''), '_', ''), '.', ''), '/', ''), ' ', ''), '*', '')))]",
     "deployerInfo": "[deployer()]",
     "deployingUserPrincipalId": "[variables('deployerInfo').objectId]",
+    "containerRegistryResourceName": "[if(not(empty(parameters('containerRegistryName'))), parameters('containerRegistryName'), take(format('cr{0}', variables('solutionSuffix')), 50))]",
     "createdBy": "[if(contains(variables('deployerInfo'), 'userPrincipalName'), split(variables('deployerInfo').userPrincipalName, '@')[0], variables('deployerInfo').objectId)]",
     "existingTags": "[coalesce(resourceGroup().tags, createObject())]",
     "useExistingAIProject": "[not(empty(parameters('existingFoundryProjectResourceId')))]",
@@ -311,10 +312,11 @@
     ],
     "aiFoundrySubscriptionId": "[if(variables('useExistingAIProject'), split(parameters('existingFoundryProjectResourceId'), '/')[2], subscription().subscriptionId)]",
     "aiFoundryResourceGroupName": "[if(variables('useExistingAIProject'), split(parameters('existingFoundryProjectResourceId'), '/')[4], resourceGroup().name)]",
-    "backendApiImageName": "[format('DOCKER|{0}.azurecr.io/da-api:{1}', parameters('containerRegistryName'), parameters('imageTag'))]",
-    "backendCsApiImageName": "[format('DOCKER|{0}.azurecr.io/da-api-dotnet:{1}', parameters('containerRegistryName'), parameters('imageTag'))]",
-    "frontendImageName": "[format('DOCKER|{0}.azurecr.io/da-app:{1}', parameters('containerRegistryName'), parameters('imageTag'))]",
-    "reactAppLayoutConfig": "{\n  \"appConfig\": {\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 70,\n        \"CHATHISTORY\": 30\n      }\n    }\n  }\n}"
+    "placeholderContainerImage": "DOCKER|mcr.microsoft.com/azuredocs/aci-helloworld:latest",
+    "backendApiImageName": "[variables('placeholderContainerImage')]",
+    "backendCsApiImageName": "[variables('placeholderContainerImage')]",
+    "frontendImageName": "[variables('placeholderContainerImage')]",
+    "reactAppLayoutConfig": "{\r\n  \"appConfig\": {\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 70,\r\n        \"CHATHISTORY\": 30\r\n      }\r\n    }\r\n  }\r\n}"
   },
   "resources": [
     {
@@ -2727,6 +2729,186 @@
       }
     },
     {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[take(format('module.container-registry.{0}', parameters('solutionName')), 64)]",
+      "resourceGroup": "[resourceGroup().name]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "solutionName": {
+            "value": "[variables('solutionSuffix')]"
+          },
+          "name": {
+            "value": "[variables('containerRegistryResourceName')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "tags": {
+            "value": "[variables('existingTags')]"
+          },
+          "sku": {
+            "value": "Standard"
+          },
+          "publicNetworkAccess": {
+            "value": "Enabled"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.44.1.10279",
+              "templateHash": "6730962297935458636"
+            }
+          },
+          "parameters": {
+            "solutionName": {
+              "type": "string",
+              "metadata": {
+                "description": "Solution name used for naming convention."
+              }
+            },
+            "name": {
+              "type": "string",
+              "defaultValue": "[replace(format('cr{0}', parameters('solutionName')), '-', '')]",
+              "metadata": {
+                "description": "Name of the container registry."
+              }
+            },
+            "location": {
+              "type": "string",
+              "metadata": {
+                "description": "Azure region for deployment."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Resource tags."
+              }
+            },
+            "sku": {
+              "type": "string",
+              "defaultValue": "Standard",
+              "allowedValues": [
+                "Basic",
+                "Standard",
+                "Premium"
+              ],
+              "metadata": {
+                "description": "SKU for the container registry."
+              }
+            },
+            "adminUserEnabled": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Enable admin user."
+              }
+            },
+            "publicNetworkAccess": {
+              "type": "string",
+              "defaultValue": "Enabled",
+              "allowedValues": [
+                "Enabled",
+                "Disabled"
+              ],
+              "metadata": {
+                "description": "Public network access setting."
+              }
+            },
+            "exportPolicyStatus": {
+              "type": "string",
+              "defaultValue": "enabled",
+              "metadata": {
+                "description": "Export policy status."
+              }
+            },
+            "retentionPolicyStatus": {
+              "type": "string",
+              "defaultValue": "disabled",
+              "metadata": {
+                "description": "Retention policy status."
+              }
+            },
+            "identity": {
+              "type": "object",
+              "defaultValue": {
+                "type": "SystemAssigned"
+              },
+              "metadata": {
+                "description": "Optional. Managed identity configuration for the resource."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.ContainerRegistry/registries",
+              "apiVersion": "2025-04-01",
+              "name": "[parameters('name')]",
+              "location": "[parameters('location')]",
+              "tags": "[parameters('tags')]",
+              "sku": {
+                "name": "[parameters('sku')]"
+              },
+              "identity": "[parameters('identity')]",
+              "properties": {
+                "adminUserEnabled": "[parameters('adminUserEnabled')]",
+                "publicNetworkAccess": "[parameters('publicNetworkAccess')]",
+                "dataEndpointEnabled": false,
+                "networkRuleBypassOptions": "AzureServices",
+                "policies": {
+                  "exportPolicy": {
+                    "status": "[parameters('exportPolicyStatus')]"
+                  },
+                  "retentionPolicy": {
+                    "status": "[parameters('retentionPolicyStatus')]",
+                    "days": 7
+                  },
+                  "trustPolicy": {
+                    "status": "disabled",
+                    "type": "Notary"
+                  }
+                },
+                "zoneRedundancy": "Disabled"
+              }
+            }
+          ],
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the container registry."
+              },
+              "value": "[parameters('name')]"
+            },
+            "loginServer": {
+              "type": "string",
+              "metadata": {
+                "description": "The login server URL."
+              },
+              "value": "[reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '2025-04-01').loginServer]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the container registry."
+              },
+              "value": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]"
+            }
+          }
+        }
+      }
+    },
+    {
       "condition": "[equals(parameters('backendRuntimeStack'), 'python')]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
@@ -2752,6 +2934,9 @@
           },
           "linuxFxVersion": {
             "value": "[variables('backendApiImageName')]"
+          },
+          "acrUseManagedIdentityCreds": {
+            "value": true
           },
           "appSettings": {
             "value": {
@@ -2800,7 +2985,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "9185565370457912659"
+              "templateHash": "13673771886806254197"
             }
           },
           "parameters": {
@@ -2913,6 +3098,13 @@
               "metadata": {
                 "description": "Optional. Managed identity configuration for the resource."
               }
+            },
+            "acrUseManagedIdentityCreds": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Use the app managed identity to authenticate ACR image pulls."
+              }
             }
           },
           "resources": [
@@ -2956,7 +3148,8 @@
                   "minTlsVersion": "1.2",
                   "healthCheckPath": "[if(not(empty(parameters('healthCheckPath'))), parameters('healthCheckPath'), null())]",
                   "webSocketsEnabled": "[parameters('webSocketsEnabled')]",
-                  "appCommandLine": "[parameters('appCommandLine')]"
+                  "appCommandLine": "[parameters('appCommandLine')]",
+                  "acrUseManagedIdentityCreds": "[parameters('acrUseManagedIdentityCreds')]"
                 },
                 "endToEndEncryptionEnabled": true
               }
@@ -3076,6 +3269,9 @@
           "linuxFxVersion": {
             "value": "[variables('backendCsApiImageName')]"
           },
+          "acrUseManagedIdentityCreds": {
+            "value": true
+          },
           "appSettings": {
             "value": {
               "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-insights.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.instrumentationKey.value]",
@@ -3119,7 +3315,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "9185565370457912659"
+              "templateHash": "13673771886806254197"
             }
           },
           "parameters": {
@@ -3232,6 +3428,13 @@
               "metadata": {
                 "description": "Optional. Managed identity configuration for the resource."
               }
+            },
+            "acrUseManagedIdentityCreds": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Use the app managed identity to authenticate ACR image pulls."
+              }
             }
           },
           "resources": [
@@ -3275,7 +3478,8 @@
                   "minTlsVersion": "1.2",
                   "healthCheckPath": "[if(not(empty(parameters('healthCheckPath'))), parameters('healthCheckPath'), null())]",
                   "webSocketsEnabled": "[parameters('webSocketsEnabled')]",
-                  "appCommandLine": "[parameters('appCommandLine')]"
+                  "appCommandLine": "[parameters('appCommandLine')]",
+                  "acrUseManagedIdentityCreds": "[parameters('acrUseManagedIdentityCreds')]"
                 },
                 "endToEndEncryptionEnabled": true
               }
@@ -3394,6 +3598,9 @@
           "linuxFxVersion": {
             "value": "[variables('frontendImageName')]"
           },
+          "acrUseManagedIdentityCreds": {
+            "value": true
+          },
           "appSettings": {
             "value": {
               "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-insights.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.instrumentationKey.value]",
@@ -3411,7 +3618,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "9185565370457912659"
+              "templateHash": "13673771886806254197"
             }
           },
           "parameters": {
@@ -3524,6 +3731,13 @@
               "metadata": {
                 "description": "Optional. Managed identity configuration for the resource."
               }
+            },
+            "acrUseManagedIdentityCreds": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Use the app managed identity to authenticate ACR image pulls."
+              }
             }
           },
           "resources": [
@@ -3567,7 +3781,8 @@
                   "minTlsVersion": "1.2",
                   "healthCheckPath": "[if(not(empty(parameters('healthCheckPath'))), parameters('healthCheckPath'), null())]",
                   "webSocketsEnabled": "[parameters('webSocketsEnabled')]",
-                  "appCommandLine": "[parameters('appCommandLine')]"
+                  "appCommandLine": "[parameters('appCommandLine')]",
+                  "acrUseManagedIdentityCreds": "[parameters('acrUseManagedIdentityCreds')]"
                 },
                 "endToEndEncryptionEnabled": true
               }
@@ -3695,6 +3910,12 @@
             "value": "[parameters('deployingUserPrincipalType')]"
           },
           "backendAppServicePrincipalId": "[if(equals(parameters('backendRuntimeStack'), 'python'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-service-pybackend.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.identityPrincipalId.value), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-service-csbackend.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.identityPrincipalId.value))]",
+          "frontendAppServicePrincipalId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-service-frontend.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.identityPrincipalId.value]"
+          },
+          "containerRegistryResourceId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.container-registry.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.resourceId.value]"
+          },
           "cosmosDbAccountName": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.cosmos-db-nosql.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.name.value]"
           }
@@ -3706,7 +3927,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "18394750597129424907"
+              "templateHash": "816923035574542416"
             }
           },
           "parameters": {
@@ -3750,6 +3971,13 @@
               "defaultValue": "",
               "metadata": {
                 "description": "Principal ID of the backend App Service system-assigned identity (empty if not deployed)."
+              }
+            },
+            "frontendAppServicePrincipalId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Principal ID of the frontend App Service system-assigned identity (empty if not deployed)."
               }
             },
             "deployerPrincipalId": {
@@ -3797,6 +4025,13 @@
               "metadata": {
                 "description": "Name of the Cosmos DB account (empty if not deployed)."
               }
+            },
+            "containerRegistryResourceId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Resource ID of the Azure Container Registry (empty if not deployed)."
+              }
             }
           },
           "variables": {
@@ -3811,7 +4046,8 @@
               "searchIndexDataContributor": "8ebe5a00-799e-43f5-93ac-243d3dce84a7",
               "searchServiceContributor": "7ca78c08-252a-4471-8644-bb5ff32d4ba0",
               "storageBlobDataContributor": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
-              "storageBlobDataReader": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1"
+              "storageBlobDataReader": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
+              "acrPull": "7f951dda-4ed3-4680-a7ca-43fe172d538d"
             }
           },
           "resources": [
@@ -3980,6 +4216,30 @@
                 "principalId": "[parameters('deployerPrincipalId')]",
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefinitions').storageBlobDataContributor)]",
                 "principalType": "[parameters('deployerPrincipalType')]"
+              }
+            },
+            {
+              "condition": "[and(not(empty(parameters('containerRegistryResourceId'))), not(empty(parameters('backendAppServicePrincipalId'))))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/')))]",
+              "name": "[guid(parameters('solutionName'), resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/'))), parameters('backendAppServicePrincipalId'), variables('roleDefinitions').acrPull)]",
+              "properties": {
+                "principalId": "[parameters('backendAppServicePrincipalId')]",
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefinitions').acrPull)]",
+                "principalType": "ServicePrincipal"
+              }
+            },
+            {
+              "condition": "[and(not(empty(parameters('containerRegistryResourceId'))), not(empty(parameters('frontendAppServicePrincipalId'))))]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/')))]",
+              "name": "[guid(parameters('solutionName'), resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/'))), parameters('frontendAppServicePrincipalId'), variables('roleDefinitions').acrPull)]",
+              "properties": {
+                "principalId": "[parameters('frontendAppServicePrincipalId')]",
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefinitions').acrPull)]",
+                "principalType": "ServicePrincipal"
               }
             },
             {
@@ -4168,8 +4428,10 @@
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.ai-search.{0}', parameters('solutionName')), 64))]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-service-csbackend.{0}', parameters('solutionName')), 64))]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-service-pybackend.{0}', parameters('solutionName')), 64))]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.container-registry.{0}', parameters('solutionName')), 64))]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.cosmos-db-nosql.{0}', parameters('solutionName')), 64))]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('aiFoundrySubscriptionId'), variables('aiFoundryResourceGroupName')), 'Microsoft.Resources/deployments', take(format('module.existing-project-setup.{0}', parameters('solutionName')), 64))]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-service-frontend.{0}', parameters('solutionName')), 64))]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.storage-account.{0}', parameters('solutionName')), 64))]"
       ]
     }
@@ -4181,6 +4443,27 @@
         "description": "Solution suffix used for naming resources"
       },
       "value": "[variables('solutionSuffix')]"
+    },
+    "AZURE_ENV_CONTAINER_REGISTRY_NAME": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the dedicated Azure Container Registry."
+      },
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.container-registry.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.name.value]"
+    },
+    "AZURE_CONTAINER_REGISTRY_ENDPOINT": {
+      "type": "string",
+      "metadata": {
+        "description": "Login server of the dedicated Azure Container Registry."
+      },
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.container-registry.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.loginServer.value]"
+    },
+    "AZURE_ENV_IMAGE_TAG": {
+      "type": "string",
+      "metadata": {
+        "description": "Docker image tag used for app deployments."
+      },
+      "value": "[parameters('imageTag')]"
     },
     "RESOURCE_GROUP_NAME": {
       "type": "string",

--- a/infra/bicep/modules/compute/app-service.bicep
+++ b/infra/bicep/modules/compute/app-service.bicep
@@ -60,6 +60,9 @@ param publicNetworkAccess string = 'Enabled'
 @description('Optional. Managed identity configuration for the resource.')
 param identity object = { type: 'SystemAssigned' }
 
+@description('Optional. Use the app managed identity to authenticate ACR image pulls.')
+param acrUseManagedIdentityCreds bool = false
+
 // ============================================================================
 // Resource Deployment
 // ============================================================================
@@ -80,6 +83,7 @@ resource appService 'Microsoft.Web/sites@2025-05-01' = {
       healthCheckPath: !empty(healthCheckPath) ? healthCheckPath : null
       webSocketsEnabled: webSocketsEnabled
       appCommandLine: appCommandLine
+      acrUseManagedIdentityCreds: acrUseManagedIdentityCreds
     }
     endToEndEncryptionEnabled: true
   }

--- a/infra/bicep/modules/identity/role-assignments.bicep
+++ b/infra/bicep/modules/identity/role-assignments.bicep
@@ -28,6 +28,9 @@ param aiSearchPrincipalId string = ''
 @description('Principal ID of the backend App Service system-assigned identity (empty if not deployed).')
 param backendAppServicePrincipalId string = ''
 
+@description('Principal ID of the frontend App Service system-assigned identity (empty if not deployed).')
+param frontendAppServicePrincipalId string = ''
+
 @description('Principal ID of the deploying user (for user access roles).')
 param deployerPrincipalId string = ''
 
@@ -48,6 +51,9 @@ param storageAccountResourceId string = ''
 
 @description('Name of the Cosmos DB account (empty if not deployed).')
 param cosmosDbAccountName string = ''
+
+@description('Resource ID of the Azure Container Registry (empty if not deployed).')
+param containerRegistryResourceId string = ''
 
 // ============================================================================
 // Derived Variables
@@ -70,6 +76,7 @@ var roleDefinitions = {
   searchServiceContributor: '7ca78c08-252a-4471-8644-bb5ff32d4ba0'
   storageBlobDataContributor: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
   storageBlobDataReader: '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
+  acrPull: '7f951dda-4ed3-4680-a7ca-43fe172d538d'
 }
 
 // ============================================================================
@@ -90,6 +97,10 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2025-08-01' existing 
 
 resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2025-10-15' existing = if (!empty(cosmosDbAccountName)) {
   name: cosmosDbAccountName
+}
+
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2025-04-01' existing = if (!empty(containerRegistryResourceId)) {
+  name: last(split(containerRegistryResourceId, '/'))
 }
 
 resource cosmosContributorRoleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions@2025-10-15' existing = if (!empty(cosmosDbAccountName)) {
@@ -301,3 +312,28 @@ resource deployerStorageBlobContributor 'Microsoft.Authorization/roleAssignments
 
 // NOTE: Deployer roles on existing AI Foundry (cross-scope) are assigned via
 // 00_build_solution.py to avoid conflicts when the deployer already has the roles.
+
+// ============================================================================
+// 6. CONTAINER REGISTRY ROLE ASSIGNMENTS
+//    Backend + Frontend App Service identities → AcrPull on the dedicated ACR
+// ============================================================================
+
+resource backendAppAcrPullAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(containerRegistryResourceId) && !empty(backendAppServicePrincipalId)) {
+  name: guid(solutionName, containerRegistry.id, backendAppServicePrincipalId, roleDefinitions.acrPull)
+  scope: containerRegistry
+  properties: {
+    principalId: backendAppServicePrincipalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleDefinitions.acrPull)
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource frontendAppAcrPullAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(containerRegistryResourceId) && !empty(frontendAppServicePrincipalId)) {
+  name: guid(solutionName, containerRegistry.id, frontendAppServicePrincipalId, roleDefinitions.acrPull)
+  scope: containerRegistry
+  properties: {
+    principalId: frontendAppServicePrincipalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleDefinitions.acrPull)
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -84,8 +84,8 @@ param embeddingDeploymentCapacity int = 80
 @description('Optional. Docker image tag for app deployments.')
 param imageTag string = 'latest_v3'
 
-@description('Optional. Name of the Azure Container Registry.')
-param containerRegistryName string = 'dataagentscontainerreg'
+@description('Optional. Name of the Azure Container Registry. Empty derives a per-deployment name.')
+param containerRegistryName string = ''
 
 @allowed(['python', 'dotnet'])
 @description('Optional. Backend runtime stack.')
@@ -296,6 +296,15 @@ output DEPLOYMENT_FLAVOR string = deploymentFlavor
 
 @description('WAF deployment type (AVM only).')
 output DEPLOYMENT_TYPE string = isAvm ? avmDeployment!.outputs.DEPLOYMENT_TYPE : 'N/A'
+
+@description('Name of the dedicated Azure Container Registry.')
+output AZURE_ENV_CONTAINER_REGISTRY_NAME string = isAvm ? avmDeployment!.outputs.AZURE_ENV_CONTAINER_REGISTRY_NAME : bicepDeployment!.outputs.AZURE_ENV_CONTAINER_REGISTRY_NAME
+
+@description('Login server of the dedicated Azure Container Registry.')
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = isAvm ? avmDeployment!.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT : bicepDeployment!.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
+
+@description('Docker image tag used for app deployments.')
+output AZURE_ENV_IMAGE_TAG string = isAvm ? avmDeployment!.outputs.AZURE_ENV_IMAGE_TAG : bicepDeployment!.outputs.AZURE_ENV_IMAGE_TAG
 
 @description('Cosmos DB account name.')
 output AZURE_COSMOSDB_ACCOUNT string = isAvm ? avmDeployment!.outputs.AZURE_COSMOSDB_ACCOUNT : bicepDeployment!.outputs.AZURE_COSMOSDB_ACCOUNT

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -37,7 +37,7 @@ param location string = resourceGroup().location
   azd:{
     type: 'location'
     usageName: [
-      'OpenAI.GlobalStandard.gpt4.1-mini,100'
+      'OpenAI.GlobalStandard.gpt-5.4-mini,100'
       'OpenAI.GlobalStandard.text-embedding-3-small,80'
     ]
   }
@@ -54,10 +54,10 @@ param azureAiServiceLocation string
 param deploymentType string = 'GlobalStandard'
 
 @description('Optional. Name of the GPT model to deploy.')
-param gptModelName string = 'gpt-4.1-mini'
+param gptModelName string = 'gpt-5.4-mini'
 
 @description('Optional. Version of the GPT model to deploy.')
-param gptModelVersion string = '2025-04-14'
+param gptModelVersion string = '2026-03-17'
 
 @description('Optional. Azure OpenAI API version.')
 param azureOpenaiAPIVersion string = '2025-01-01-preview'

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "6289238347285422321"
+      "templateHash": "12984022811060325727"
     }
   },
   "parameters": {
@@ -143,9 +143,9 @@
     },
     "containerRegistryName": {
       "type": "string",
-      "defaultValue": "dataagentscontainerreg",
+      "defaultValue": "",
       "metadata": {
-        "description": "Optional. Name of the Azure Container Registry."
+        "description": "Optional. Name of the Azure Container Registry. Empty derives a per-deployment name."
       }
     },
     "backendRuntimeStack": {
@@ -473,7 +473,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "1138736693056161647"
+              "templateHash": "2782862649368459379"
             }
           },
           "parameters": {
@@ -662,9 +662,9 @@
             },
             "containerRegistryName": {
               "type": "string",
-              "defaultValue": "dataagentscontainerreg",
+              "defaultValue": "",
               "metadata": {
-                "description": "Optional. Name of the Azure Container Registry."
+                "description": "Optional. Name of the Azure Container Registry. Empty derives a per-deployment name (cr<suffix>)."
               }
             },
             "backendRuntimeStack": {
@@ -797,6 +797,8 @@
           },
           "variables": {
             "solutionSuffix": "[toLower(trim(replace(replace(replace(replace(replace(replace(format('{0}{1}', parameters('solutionName'), parameters('solutionUniqueText')), '-', ''), '_', ''), '.', ''), '/', ''), ' ', ''), '*', '')))]",
+            "containerRegistryResourceName": "[if(not(empty(parameters('containerRegistryName'))), parameters('containerRegistryName'), take(format('cr{0}', variables('solutionSuffix')), 50))]",
+            "placeholderContainerImage": "DOCKER|mcr.microsoft.com/azuredocs/aci-helloworld:latest",
             "deployerInfo": "[deployer()]",
             "deployingUserPrincipalId": "[variables('deployerInfo').objectId]",
             "createdBy": "[if(contains(variables('deployerInfo'), 'userPrincipalName'), split(variables('deployerInfo').userPrincipalName, '@')[0], variables('deployerInfo').objectId)]",
@@ -842,7 +844,8 @@
               "privatelink.blob.core.windows.net",
               "privatelink.search.windows.net",
               "privatelink.database.windows.net",
-              "privatelink.azurewebsites.net"
+              "privatelink.azurewebsites.net",
+              "privatelink.azurecr.io"
             ],
             "dnsZoneIndex": {
               "cognitiveServices": 0,
@@ -852,7 +855,8 @@
               "blob": 4,
               "search": 5,
               "sqlServer": 6,
-              "webApp": 7
+              "webApp": 7,
+              "containerRegistry": 8
             },
             "aiModelDeployments": [
               {
@@ -46211,6 +46215,4108 @@
                 "virtualNetwork"
               ]
             },
+            "containerRegistry": {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[take(format('module.container-registry.{0}', parameters('solutionName')), 64)]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "solutionName": {
+                    "value": "[variables('solutionSuffix')]"
+                  },
+                  "name": {
+                    "value": "[variables('containerRegistryResourceName')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "tags": {
+                    "value": "[parameters('tags')]"
+                  },
+                  "enableTelemetry": {
+                    "value": "[parameters('enableTelemetry')]"
+                  },
+                  "sku": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Premium'), createObject('value', 'Standard'))]",
+                  "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
+                  "networkRuleSetDefaultAction": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Deny'), createObject('value', 'Allow'))]",
+                  "exportPolicyStatus": "[if(parameters('enablePrivateNetworking'), createObject('value', 'disabled'), createObject('value', 'enabled'))]",
+                  "enablePrivateNetworking": {
+                    "value": "[parameters('enablePrivateNetworking')]"
+                  },
+                  "privateEndpointSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.backendSubnetResourceId.value), createObject('value', ''))]",
+                  "privateDnsZoneResourceIds": "[if(parameters('enablePrivateNetworking'), createObject('value', createArray(reference(format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').containerRegistry)).outputs.resourceId.value)), createObject('value', createArray()))]"
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.44.1.10279",
+                      "templateHash": "1223988259594936060"
+                    }
+                  },
+                  "parameters": {
+                    "solutionName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Solution name used for naming convention."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "defaultValue": "[replace(format('cr{0}', parameters('solutionName')), '-', '')]",
+                      "metadata": {
+                        "description": "Name of the container registry."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Azure region for deployment."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "defaultValue": {},
+                      "metadata": {
+                        "description": "Resource tags."
+                      }
+                    },
+                    "sku": {
+                      "type": "string",
+                      "defaultValue": "Standard",
+                      "allowedValues": [
+                        "Basic",
+                        "Standard",
+                        "Premium"
+                      ],
+                      "metadata": {
+                        "description": "SKU for the container registry."
+                      }
+                    },
+                    "adminUserEnabled": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Enable admin user for the registry."
+                      }
+                    },
+                    "publicNetworkAccess": {
+                      "type": "string",
+                      "defaultValue": "Enabled",
+                      "allowedValues": [
+                        "Enabled",
+                        "Disabled"
+                      ],
+                      "metadata": {
+                        "description": "Public network access setting."
+                      }
+                    },
+                    "exportPolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "enabled",
+                      "metadata": {
+                        "description": "Export policy status. Must be \"enabled\" when publicNetworkAccess is \"Enabled\"."
+                      }
+                    },
+                    "acrPullPrincipalIds": {
+                      "type": "array",
+                      "defaultValue": [],
+                      "metadata": {
+                        "description": "Principal IDs to assign AcrPull role."
+                      }
+                    },
+                    "acrPushPrincipalIds": {
+                      "type": "array",
+                      "defaultValue": [],
+                      "metadata": {
+                        "description": "Principal IDs to assign AcrPush role (typically the deployer)."
+                      }
+                    },
+                    "acrPushPrincipalType": {
+                      "type": "string",
+                      "defaultValue": "User",
+                      "allowedValues": [
+                        "User",
+                        "ServicePrincipal",
+                        "Group"
+                      ],
+                      "metadata": {
+                        "description": "Principal type for AcrPush assignments (User for azd user, ServicePrincipal for CI)."
+                      }
+                    },
+                    "enablePrivateNetworking": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Enable private networking."
+                      }
+                    },
+                    "privateEndpointSubnetId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Subnet resource ID for private endpoint."
+                      }
+                    },
+                    "privateDnsZoneResourceIds": {
+                      "type": "array",
+                      "defaultValue": [],
+                      "metadata": {
+                        "description": "Private DNS zone resource IDs for private endpoint."
+                      }
+                    },
+                    "networkRuleSetDefaultAction": {
+                      "type": "string",
+                      "defaultValue": "Allow",
+                      "allowedValues": [
+                        "Allow",
+                        "Deny"
+                      ],
+                      "metadata": {
+                        "description": "Default action for the network rule set. Use Allow when no private endpoint is in place; Deny for private-only."
+                      }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Enable Azure telemetry collection."
+                      }
+                    },
+                    "managedIdentities": {
+                      "type": "object",
+                      "defaultValue": {
+                        "systemAssigned": true
+                      },
+                      "metadata": {
+                        "description": "Optional. Managed identities for the resource."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "copy": [
+                      {
+                        "name": "pullRoleAssignments",
+                        "count": "[length(parameters('acrPullPrincipalIds'))]",
+                        "input": {
+                          "principalId": "[parameters('acrPullPrincipalIds')[copyIndex('pullRoleAssignments')]]",
+                          "roleDefinitionIdOrName": "[variables('acrPullRoleId')]",
+                          "principalType": "ServicePrincipal"
+                        }
+                      },
+                      {
+                        "name": "pushRoleAssignments",
+                        "count": "[length(parameters('acrPushPrincipalIds'))]",
+                        "input": {
+                          "principalId": "[parameters('acrPushPrincipalIds')[copyIndex('pushRoleAssignments')]]",
+                          "roleDefinitionIdOrName": "[variables('acrPushRoleId')]",
+                          "principalType": "[parameters('acrPushPrincipalType')]"
+                        }
+                      },
+                      {
+                        "name": "dnsZoneConfigs",
+                        "count": "[length(parameters('privateDnsZoneResourceIds'))]",
+                        "input": {
+                          "name": "[format('config{0}', copyIndex('dnsZoneConfigs'))]",
+                          "privateDnsZoneResourceId": "[parameters('privateDnsZoneResourceIds')[copyIndex('dnsZoneConfigs')]]"
+                        }
+                      }
+                    ],
+                    "acrPullRoleId": "7f951dda-4ed3-4680-a7ca-43fe172d538d",
+                    "acrPushRoleId": "8311e382-0749-4cb8-b61a-304f252e45ec",
+                    "roleAssignments": "[concat(if(not(empty(parameters('acrPullPrincipalIds'))), variables('pullRoleAssignments'), createArray()), if(not(empty(parameters('acrPushPrincipalIds'))), variables('pushRoleAssignments'), createArray()))]",
+                    "privateEndpointConfig": "[if(and(parameters('enablePrivateNetworking'), not(empty(parameters('privateEndpointSubnetId')))), createArray(createObject('subnetResourceId', parameters('privateEndpointSubnetId'), 'privateDnsZoneGroup', if(not(empty(parameters('privateDnsZoneResourceIds'))), createObject('privateDnsZoneGroupConfigs', variables('dnsZoneConfigs')), null()))), createArray())]"
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2025-04-01",
+                      "name": "[take(format('avm.res.containerregistry.{0}', parameters('name')), 64)]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[parameters('name')]"
+                          },
+                          "location": {
+                            "value": "[parameters('location')]"
+                          },
+                          "tags": {
+                            "value": "[parameters('tags')]"
+                          },
+                          "enableTelemetry": {
+                            "value": "[parameters('enableTelemetry')]"
+                          },
+                          "acrSku": {
+                            "value": "[parameters('sku')]"
+                          },
+                          "acrAdminUserEnabled": {
+                            "value": "[parameters('adminUserEnabled')]"
+                          },
+                          "publicNetworkAccess": {
+                            "value": "[parameters('publicNetworkAccess')]"
+                          },
+                          "exportPolicyStatus": {
+                            "value": "[parameters('exportPolicyStatus')]"
+                          },
+                          "roleAssignments": "[if(not(empty(variables('roleAssignments'))), createObject('value', variables('roleAssignments')), createObject('value', createArray()))]",
+                          "privateEndpoints": {
+                            "value": "[variables('privateEndpointConfig')]"
+                          },
+                          "networkRuleSetDefaultAction": {
+                            "value": "[parameters('networkRuleSetDefaultAction')]"
+                          },
+                          "managedIdentities": {
+                            "value": "[parameters('managedIdentities')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.42.1.51946",
+                              "templateHash": "1509121545318808417"
+                            },
+                            "name": "Azure Container Registries (ACR)",
+                            "description": "This module deploys an Azure Container Registry (ACR)."
+                          },
+                          "definitions": {
+                            "privateEndpointOutputType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "The name of the private endpoint."
+                                  }
+                                },
+                                "resourceId": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "The resource ID of the private endpoint."
+                                  }
+                                },
+                                "groupId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "The group Id for the private endpoint Group."
+                                  }
+                                },
+                                "customDnsConfigs": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "fqdn": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "metadata": {
+                                          "description": "FQDN that resolves to private endpoint IP address."
+                                        }
+                                      },
+                                      "ipAddresses": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "metadata": {
+                                          "description": "A list of private IP addresses of the private endpoint."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "metadata": {
+                                    "description": "The custom DNS configurations of the private endpoint."
+                                  }
+                                },
+                                "networkInterfaceResourceIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "metadata": {
+                                    "description": "The IDs of the network interfaces associated with the private endpoint."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true
+                              }
+                            },
+                            "credentialSetType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The name of the credential set."
+                                  }
+                                },
+                                "managedIdentities": {
+                                  "$ref": "#/definitions/managedIdentityOnlySysAssignedType",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The managed identity definition for this resource."
+                                  }
+                                },
+                                "authCredentials": {
+                                  "type": "array",
+                                  "items": {
+                                    "$ref": "#/definitions/authCredentialsType"
+                                  },
+                                  "metadata": {
+                                    "description": "Required. List of authentication credentials stored for an upstream. Usually consists of a primary and an optional secondary credential."
+                                  }
+                                },
+                                "loginServer": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The credentials are stored for this upstream or login server."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "The type for a credential set."
+                              }
+                            },
+                            "scopeMapsType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the scope map."
+                                  }
+                                },
+                                "actions": {
+                                  "type": "array",
+                                  "metadata": {
+                                    "__bicep_resource_derived_type!": {
+                                      "source": "Microsoft.ContainerRegistry/registries/scopeMaps@2025-03-01-preview#properties/properties/properties/actions"
+                                    },
+                                    "description": "Required. The list of scoped permissions for registry artifacts."
+                                  }
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The user friendly description of the scope map."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "The type for a scope map."
+                              }
+                            },
+                            "cacheRuleType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the cache rule. Will be derived from the source repository name if not defined."
+                                  }
+                                },
+                                "sourceRepository": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. Source repository pulled from upstream."
+                                  }
+                                },
+                                "targetRepository": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Target repository specified in docker pull command. E.g.: docker pull myregistry.azurecr.io/{targetRepository}:{tag}."
+                                  }
+                                },
+                                "credentialSetResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The resource ID of the credential store which is associated with the cache rule."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "The type for a cache rule."
+                              }
+                            },
+                            "replicationType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The name of the replication."
+                                  }
+                                },
+                                "location": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Location for all resources."
+                                  }
+                                },
+                                "tags": {
+                                  "type": "object",
+                                  "metadata": {
+                                    "__bicep_resource_derived_type!": {
+                                      "source": "Microsoft.ContainerRegistry/registries/replications@2025-03-01-preview#properties/tags"
+                                    },
+                                    "description": "Optional. Tags of the resource."
+                                  },
+                                  "nullable": true
+                                },
+                                "regionEndpointEnabled": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specifies whether the replication regional endpoint is enabled. Requests will not be routed to a replication whose regional endpoint is disabled, however its data will continue to be synced with other replications."
+                                  }
+                                },
+                                "zoneRedundancy": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "__bicep_resource_derived_type!": {
+                                      "source": "Microsoft.ContainerRegistry/registries@2025-03-01-preview#properties/properties/properties/zoneRedundancy"
+                                    },
+                                    "description": "Optional. Whether or not zone redundancy is enabled for this container registry."
+                                  },
+                                  "nullable": true
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "The type for a replication."
+                              }
+                            },
+                            "taskType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The name of the task."
+                                  }
+                                },
+                                "location": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Location for all resources."
+                                  }
+                                },
+                                "tags": {
+                                  "type": "object",
+                                  "metadata": {
+                                    "__bicep_resource_derived_type!": {
+                                      "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/tags"
+                                    },
+                                    "description": "Optional. Tags of the resource."
+                                  },
+                                  "nullable": true
+                                },
+                                "platform": {
+                                  "type": "object",
+                                  "metadata": {
+                                    "__bicep_resource_derived_type!": {
+                                      "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/platform"
+                                    },
+                                    "description": "Optional. The platform properties for the task."
+                                  },
+                                  "nullable": true
+                                },
+                                "step": {
+                                  "type": "object",
+                                  "metadata": {
+                                    "__bicep_resource_derived_type!": {
+                                      "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/step"
+                                    },
+                                    "description": "Optional. The step properties for the task."
+                                  },
+                                  "nullable": true
+                                },
+                                "trigger": {
+                                  "type": "object",
+                                  "metadata": {
+                                    "__bicep_resource_derived_type!": {
+                                      "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/trigger"
+                                    },
+                                    "description": "Optional. The trigger properties for the task."
+                                  },
+                                  "nullable": true
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "__bicep_resource_derived_type!": {
+                                      "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/status"
+                                    },
+                                    "description": "Optional. The status of the task at the time the operation was called."
+                                  },
+                                  "nullable": true
+                                },
+                                "timeout": {
+                                  "type": "int",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The timeout in seconds for the task to run before it is automatically disabled."
+                                  }
+                                },
+                                "agentConfiguration": {
+                                  "type": "object",
+                                  "metadata": {
+                                    "__bicep_resource_derived_type!": {
+                                      "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/agentConfiguration"
+                                    },
+                                    "description": "Optional. The agent configuration for the task."
+                                  },
+                                  "nullable": true
+                                },
+                                "agentPoolName": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the agent pool to run the task on. If not specified, the task will run on Microsoft-hosted agents."
+                                  }
+                                },
+                                "isSystemTask": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Whether this is a system task or not. System tasks have some additional restrictions and are used for internal purposes by Microsoft services, such as Azure DevOps pipelines integration."
+                                  }
+                                },
+                                "logTemplate": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The log template for the task to use when creating logs in Log Analytics."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "The type for a task."
+                              }
+                            },
+                            "tokenType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The name of the token."
+                                  }
+                                },
+                                "scopeMapResourceId": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The resource ID of the scope map which defines the permissions for this token."
+                                  }
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "__bicep_resource_derived_type!": {
+                                      "source": "Microsoft.ContainerRegistry/registries/tokens@2025-11-01#properties/properties/properties/status"
+                                    },
+                                    "description": "Optional. The status of the token at the time the operation was called."
+                                  },
+                                  "nullable": true
+                                },
+                                "credentials": {
+                                  "type": "array",
+                                  "items": {
+                                    "$ref": "#/definitions/authCredentialsType"
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The list of credentials associated with the token. Usually consists of a primary and an optional secondary credential."
+                                  }
+                                }
+                              }
+                            },
+                            "webhookType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "minLength": 5,
+                                  "maxLength": 50,
+                                  "metadata": {
+                                    "description": "Optional. The name of the registry webhook."
+                                  }
+                                },
+                                "serviceUri": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The service URI for the webhook to post notifications."
+                                  }
+                                },
+                                "status": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "__bicep_resource_derived_type!": {
+                                      "source": "Microsoft.ContainerRegistry/registries/webhooks@2025-03-01-preview#properties/properties/properties/status"
+                                    },
+                                    "description": "Optional. The status of the webhook at the time the operation was called."
+                                  },
+                                  "nullable": true
+                                },
+                                "action": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The list of actions that trigger the webhook to post notifications."
+                                  }
+                                },
+                                "location": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Location for all resources."
+                                  }
+                                },
+                                "tags": {
+                                  "type": "object",
+                                  "metadata": {
+                                    "__bicep_resource_derived_type!": {
+                                      "source": "Microsoft.ContainerRegistry/registries/webhooks@2025-03-01-preview#properties/tags"
+                                    },
+                                    "description": "Optional. Tags of the resource."
+                                  },
+                                  "nullable": true
+                                },
+                                "customHeaders": {
+                                  "type": "object",
+                                  "metadata": {
+                                    "__bicep_resource_derived_type!": {
+                                      "source": "Microsoft.ContainerRegistry/registries/webhooks@2025-03-01-preview#properties/properties/properties/customHeaders"
+                                    },
+                                    "description": "Optional. Custom headers that will be added to the webhook notifications."
+                                  },
+                                  "nullable": true
+                                },
+                                "scope": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The scope of repositories where the event can be triggered. For example, 'foo:*' means events for all tags under repository 'foo'. 'foo:bar' means events for 'foo:bar' only. 'foo' is equivalent to 'foo:latest'. Empty means all events."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "The type for a webhook."
+                              }
+                            },
+                            "_1.privateEndpointCustomDnsConfigType": {
+                              "type": "object",
+                              "properties": {
+                                "fqdn": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. FQDN that resolves to private endpoint IP address."
+                                  }
+                                },
+                                "ipAddresses": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "metadata": {
+                                    "description": "Required. A list of private IP addresses of the private endpoint."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                }
+                              }
+                            },
+                            "_1.privateEndpointIpConfigurationType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The name of the resource that is unique within a resource group."
+                                  }
+                                },
+                                "properties": {
+                                  "type": "object",
+                                  "properties": {
+                                    "groupId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to."
+                                      }
+                                    },
+                                    "memberName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to."
+                                      }
+                                    },
+                                    "privateIPAddress": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. A private IP address obtained from the private endpoint's subnet."
+                                      }
+                                    }
+                                  },
+                                  "metadata": {
+                                    "description": "Required. Properties of private endpoint IP configurations."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                }
+                              }
+                            },
+                            "_1.privateEndpointPrivateDnsZoneGroupType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the Private DNS Zone Group."
+                                  }
+                                },
+                                "privateDnsZoneGroupConfigs": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "metadata": {
+                                          "description": "Optional. The name of the private DNS Zone Group config."
+                                        }
+                                      },
+                                      "privateDnsZoneResourceId": {
+                                        "type": "string",
+                                        "metadata": {
+                                          "description": "Required. The resource id of the private DNS zone."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "metadata": {
+                                    "description": "Required. The private DNS Zone Groups to associate the Private Endpoint. A DNS Zone Group can support up to 5 DNS zones."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                }
+                              }
+                            },
+                            "authCredentialsType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The name of the credential."
+                                  }
+                                },
+                                "usernameSecretIdentifier": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. KeyVault Secret URI for accessing the username."
+                                  }
+                                },
+                                "passwordSecretIdentifier": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. KeyVault Secret URI for accessing the password."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "The type for auth credentials.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "credential-set/main.bicep"
+                                }
+                              }
+                            },
+                            "customerManagedKeyWithAutoRotateType": {
+                              "type": "object",
+                              "properties": {
+                                "keyVaultResourceId": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The resource ID of a key vault to reference a customer managed key for encryption from."
+                                  }
+                                },
+                                "keyName": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The name of the customer managed key to use for encryption."
+                                  }
+                                },
+                                "keyVersion": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting."
+                                  }
+                                },
+                                "autoRotationEnabled": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used."
+                                  }
+                                },
+                                "userAssignedIdentityResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a customer-managed key. To be used if the resource type supports auto-rotation of the customer-managed key.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                }
+                              }
+                            },
+                            "diagnosticSettingFullType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the diagnostic setting."
+                                  }
+                                },
+                                "logCategoriesAndGroups": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "category": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "metadata": {
+                                          "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
+                                        }
+                                      },
+                                      "categoryGroup": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "metadata": {
+                                          "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
+                                        }
+                                      },
+                                      "enabled": {
+                                        "type": "bool",
+                                        "nullable": true,
+                                        "metadata": {
+                                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
+                                  }
+                                },
+                                "metricCategories": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "category": {
+                                        "type": "string",
+                                        "metadata": {
+                                          "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
+                                        }
+                                      },
+                                      "enabled": {
+                                        "type": "bool",
+                                        "nullable": true,
+                                        "metadata": {
+                                          "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
+                                  }
+                                },
+                                "logAnalyticsDestinationType": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "AzureDiagnostics",
+                                    "Dedicated"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
+                                  }
+                                },
+                                "workspaceResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                                  }
+                                },
+                                "storageAccountResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                                  }
+                                },
+                                "eventHubAuthorizationRuleResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
+                                  }
+                                },
+                                "eventHubName": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                                  }
+                                },
+                                "marketplacePartnerResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                }
+                              }
+                            },
+                            "lockType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specify the name of lock."
+                                  }
+                                },
+                                "kind": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "CanNotDelete",
+                                    "None",
+                                    "ReadOnly"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specify the type of lock."
+                                  }
+                                },
+                                "notes": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specify the notes of the lock."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a lock.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                }
+                              }
+                            },
+                            "managedIdentityAllType": {
+                              "type": "object",
+                              "properties": {
+                                "systemAssigned": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Enables system assigned managed identity on the resource."
+                                  }
+                                },
+                                "userAssignedResourceIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The resource ID(s) to assign to the resource. Required if a user assigned identity is used for encryption."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                }
+                              }
+                            },
+                            "managedIdentityOnlySysAssignedType": {
+                              "type": "object",
+                              "properties": {
+                                "systemAssigned": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Enables system assigned managed identity on the resource."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a managed identity configuration. To be used if only system-assigned identities are supported by the resource provider.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                }
+                              }
+                            },
+                            "privateEndpointSingleServiceType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the Private Endpoint."
+                                  }
+                                },
+                                "location": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The location to deploy the Private Endpoint to."
+                                  }
+                                },
+                                "privateLinkServiceConnectionName": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the private link connection to create."
+                                  }
+                                },
+                                "service": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The subresource to deploy the Private Endpoint for. For example \"vault\" for a Key Vault Private Endpoint."
+                                  }
+                                },
+                                "subnetResourceId": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                                  }
+                                },
+                                "resourceGroupResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The resource ID of the Resource Group the Private Endpoint will be created in. If not specified, the Resource Group of the provided Virtual Network Subnet is used."
+                                  }
+                                },
+                                "privateDnsZoneGroup": {
+                                  "$ref": "#/definitions/_1.privateEndpointPrivateDnsZoneGroupType",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The private DNS Zone Group to configure for the Private Endpoint."
+                                  }
+                                },
+                                "isManualConnection": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. If Manual Private Link Connection is required."
+                                  }
+                                },
+                                "manualConnectionRequestMessage": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "maxLength": 140,
+                                  "metadata": {
+                                    "description": "Optional. A message passed to the owner of the remote resource with the manual connection request."
+                                  }
+                                },
+                                "customDnsConfigs": {
+                                  "type": "array",
+                                  "items": {
+                                    "$ref": "#/definitions/_1.privateEndpointCustomDnsConfigType"
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Custom DNS configurations."
+                                  }
+                                },
+                                "ipConfigurations": {
+                                  "type": "array",
+                                  "items": {
+                                    "$ref": "#/definitions/_1.privateEndpointIpConfigurationType"
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. A list of IP configurations of the Private Endpoint. This will be used to map to the first-party Service endpoints."
+                                  }
+                                },
+                                "applicationSecurityGroupResourceIds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Application security groups in which the Private Endpoint IP configuration is included."
+                                  }
+                                },
+                                "customNetworkInterfaceName": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The custom name of the network interface attached to the Private Endpoint."
+                                  }
+                                },
+                                "lock": {
+                                  "$ref": "#/definitions/lockType",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specify the type of lock."
+                                  }
+                                },
+                                "roleAssignments": {
+                                  "type": "array",
+                                  "items": {
+                                    "$ref": "#/definitions/roleAssignmentType"
+                                  },
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Array of role assignments to create."
+                                  }
+                                },
+                                "tags": {
+                                  "type": "object",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "__bicep_resource_derived_type!": {
+                                      "source": "Microsoft.Network/privateEndpoints@2024-07-01#properties/tags"
+                                    },
+                                    "description": "Optional. Tags to be applied on all resources/Resource Groups in this deployment."
+                                  }
+                                },
+                                "enableTelemetry": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Enable/Disable usage telemetry for module."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a private endpoint. To be used if the private endpoint's default service / groupId can be assumed (i.e., for services that only have one Private Endpoint type like 'vault' for key vault).",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                }
+                              }
+                            },
+                            "roleAssignmentType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                                  }
+                                },
+                                "roleDefinitionIdOrName": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                                  }
+                                },
+                                "principalId": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                                  }
+                                },
+                                "principalType": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "Device",
+                                    "ForeignGroup",
+                                    "Group",
+                                    "ServicePrincipal",
+                                    "User"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The principal type of the assigned principal ID."
+                                  }
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The description of the role assignment."
+                                  }
+                                },
+                                "condition": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                                  }
+                                },
+                                "conditionVersion": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "2.0"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Version of the condition."
+                                  }
+                                },
+                                "delegatedManagedIdentityResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a role assignment.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                }
+                              }
+                            }
+                          },
+                          "parameters": {
+                            "name": {
+                              "type": "string",
+                              "minLength": 5,
+                              "maxLength": 50,
+                              "metadata": {
+                                "description": "Required. Name of your Azure Container Registry."
+                              }
+                            },
+                            "acrAdminUserEnabled": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "Optional. Enable admin user that have push / pull permission to the registry."
+                              }
+                            },
+                            "location": {
+                              "type": "string",
+                              "defaultValue": "[resourceGroup().location]",
+                              "metadata": {
+                                "description": "Optional. Location for all resources."
+                              }
+                            },
+                            "roleAssignments": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/roleAssignmentType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Array of role assignments to create."
+                              }
+                            },
+                            "autoGeneratedDomainNameLabelScope": {
+                              "type": "string",
+                              "nullable": true,
+                              "allowedValues": [
+                                "NoReuse",
+                                "ResourceGroupReuse",
+                                "SubscriptionReuse",
+                                "TenantReuse",
+                                "Unsecure"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The domain name label reuse scope."
+                              }
+                            },
+                            "roleAssignmentMode": {
+                              "type": "string",
+                              "nullable": true,
+                              "allowedValues": [
+                                "AbacRepositoryPermissions",
+                                "LegacyRegistryPermissions"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The registry permissions role assignment mode."
+                              }
+                            },
+                            "acrSku": {
+                              "type": "string",
+                              "defaultValue": "Premium",
+                              "allowedValues": [
+                                "Basic",
+                                "Premium",
+                                "Standard"
+                              ],
+                              "metadata": {
+                                "description": "Optional. Tier of your Azure container registry."
+                              }
+                            },
+                            "exportPolicyStatus": {
+                              "type": "string",
+                              "defaultValue": "disabled",
+                              "allowedValues": [
+                                "disabled",
+                                "enabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The value that indicates whether the export policy is enabled or not."
+                              }
+                            },
+                            "quarantinePolicyStatus": {
+                              "type": "string",
+                              "defaultValue": "disabled",
+                              "allowedValues": [
+                                "disabled",
+                                "enabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The value that indicates whether the quarantine policy is enabled or not. Note, requires the 'acrSku' to be 'Premium'."
+                              }
+                            },
+                            "trustPolicyStatus": {
+                              "type": "string",
+                              "defaultValue": "disabled",
+                              "allowedValues": [
+                                "disabled",
+                                "enabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The value that indicates whether the trust policy is enabled or not. Note, requires the 'acrSku' to be 'Premium'."
+                              }
+                            },
+                            "retentionPolicyStatus": {
+                              "type": "string",
+                              "defaultValue": "enabled",
+                              "allowedValues": [
+                                "disabled",
+                                "enabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The value that indicates whether the retention policy is enabled or not."
+                              }
+                            },
+                            "retentionPolicyDays": {
+                              "type": "int",
+                              "defaultValue": 15,
+                              "metadata": {
+                                "description": "Optional. The number of days to retain an untagged manifest after which it gets purged."
+                              }
+                            },
+                            "azureADAuthenticationAsArmPolicyStatus": {
+                              "type": "string",
+                              "defaultValue": "disabled",
+                              "allowedValues": [
+                                "disabled",
+                                "enabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The value that indicates whether the policy for using ARM audience token for a container registry is enabled or not. Default is disabled."
+                              }
+                            },
+                            "softDeletePolicyStatus": {
+                              "type": "string",
+                              "defaultValue": "disabled",
+                              "allowedValues": [
+                                "disabled",
+                                "enabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. Soft Delete policy status. Default is disabled."
+                              }
+                            },
+                            "softDeletePolicyDays": {
+                              "type": "int",
+                              "defaultValue": 7,
+                              "metadata": {
+                                "description": "Optional. The number of days after which a soft-deleted item is permanently deleted."
+                              }
+                            },
+                            "dataEndpointEnabled": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "Optional. Enable a single data endpoint per region for serving data. Not relevant in case of disabled public access. Note, requires the 'acrSku' to be 'Premium'."
+                              }
+                            },
+                            "publicNetworkAccess": {
+                              "type": "string",
+                              "nullable": true,
+                              "allowedValues": [
+                                "Enabled",
+                                "Disabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and networkRuleSetIpRules are not set.  Note, requires the 'acrSku' to be 'Premium'."
+                              }
+                            },
+                            "networkRuleBypassOptions": {
+                              "type": "string",
+                              "defaultValue": "AzureServices",
+                              "allowedValues": [
+                                "AzureServices",
+                                "None"
+                              ],
+                              "metadata": {
+                                "description": "Optional. Whether to allow trusted Azure services to access a network restricted registry."
+                              }
+                            },
+                            "networkRuleSetDefaultAction": {
+                              "type": "string",
+                              "defaultValue": "Deny",
+                              "allowedValues": [
+                                "Allow",
+                                "Deny"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The default action of allow or deny when no other rules match."
+                              }
+                            },
+                            "networkRuleSetIpRules": {
+                              "type": "array",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The IP ACL rules. Note, requires the 'acrSku' to be 'Premium'. Set to an empty array to explicitly configure no allowed IPs."
+                              }
+                            },
+                            "privateEndpoints": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/privateEndpointSingleServiceType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. Note, requires the 'acrSku' to be 'Premium'."
+                              }
+                            },
+                            "zoneRedundancy": {
+                              "type": "string",
+                              "defaultValue": "Enabled",
+                              "allowedValues": [
+                                "Disabled",
+                                "Enabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. Whether or not zone redundancy is enabled for this container registry."
+                              }
+                            },
+                            "replications": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/replicationType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. All replications to create."
+                              }
+                            },
+                            "webhooks": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/webhookType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. All webhooks to create."
+                              }
+                            },
+                            "lock": {
+                              "$ref": "#/definitions/lockType",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The lock settings of the service."
+                              }
+                            },
+                            "managedIdentities": {
+                              "$ref": "#/definitions/managedIdentityAllType",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The managed identity definition for this resource."
+                              }
+                            },
+                            "tags": {
+                              "type": "object",
+                              "metadata": {
+                                "__bicep_resource_derived_type!": {
+                                  "source": "Microsoft.ContainerRegistry/registries@2025-04-01#properties/tags"
+                                },
+                                "description": "Optional. Tags of the resource."
+                              },
+                              "nullable": true
+                            },
+                            "enableTelemetry": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Enable/Disable usage telemetry for module."
+                              }
+                            },
+                            "diagnosticSettings": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/diagnosticSettingFullType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The diagnostic settings of the service. If neither metrics nor logs are specified, all metrics & logs are configured by default. If either one is specified, the other is ignored."
+                              }
+                            },
+                            "anonymousPullEnabled": {
+                              "type": "bool",
+                              "defaultValue": false,
+                              "metadata": {
+                                "description": "Optional. Enables registry-wide pull from unauthenticated clients. It's in preview and available in the Standard and Premium service tiers."
+                              }
+                            },
+                            "customerManagedKey": {
+                              "$ref": "#/definitions/customerManagedKeyWithAutoRotateType",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The customer managed key definition."
+                              }
+                            },
+                            "cacheRules": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/cacheRuleType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Array of Cache Rules."
+                              }
+                            },
+                            "credentialSets": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/credentialSetType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Array of Credential Sets."
+                              }
+                            },
+                            "scopeMaps": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/scopeMapsType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Scope maps setting."
+                              }
+                            },
+                            "tokens": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/tokenType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Tokens to create for the container registry."
+                              }
+                            },
+                            "tasks": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/taskType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Array of ACR Tasks to create."
+                              }
+                            }
+                          },
+                          "variables": {
+                            "copy": [
+                              {
+                                "name": "formattedRoleAssignments",
+                                "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                                "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                              }
+                            ],
+                            "enableReferencedModulesTelemetry": false,
+                            "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
+                            "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned, UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
+                            "builtInRoleNames": {
+                              "AcrDelete": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c2f4ef07-c644-48eb-af81-4b1b4947fb11')]",
+                              "AcrImageSigner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '6cef56e8-d556-48e5-a04f-b8e64114680f')]",
+                              "AcrPull": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
+                              "AcrPush": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8311e382-0749-4cb8-b61a-304f252e45ec')]",
+                              "AcrQuarantineReader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'cdda3590-29a3-44f6-95f2-9f980659eb04')]",
+                              "AcrQuarantineWriter": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c8d4ff99-41c3-41a8-9f60-21dfdad59608')]",
+                              "Container Registry Repository Catalog Lister": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'bfdb9389-c9a5-478a-bb2f-ba9ca092c3c7')]",
+                              "Container Registry Repository Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2efddaa5-3f1f-4df3-97df-af3f13818f4c')]",
+                              "Container Registry Repository Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b93aa761-3e63-49ed-ac28-beffa264f7ac')]",
+                              "Container Registry Repository Writer": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2a1e307c-b015-4ebd-883e-5b7698a07328')]",
+                              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                              "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                              "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
+                            },
+                            "publicNetworkAccessMode": "[if(not(empty(parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(and(not(empty(parameters('privateEndpoints'))), empty(parameters('networkRuleSetIpRules'))), 'Disabled', null()))]",
+                            "shouldConfigureNetworkRuleSet": "[or(not(equals(parameters('networkRuleSetIpRules'), null())), and(equals(variables('publicNetworkAccessMode'), 'Enabled'), equals(parameters('networkRuleSetDefaultAction'), 'Deny')))]"
+                          },
+                          "resources": {
+                            "cMKKeyVault::cMKKey": {
+                              "condition": "[and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName')))))]",
+                              "existing": true,
+                              "type": "Microsoft.KeyVault/vaults/keys",
+                              "apiVersion": "2024-11-01",
+                              "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+                              "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+                              "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]"
+                            },
+                            "avmTelemetry": {
+                              "condition": "[parameters('enableTelemetry')]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('46d3xbcp.res.containerregistry-registry.{0}.{1}', replace('0.12.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                              "properties": {
+                                "mode": "Incremental",
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "resources": [],
+                                  "outputs": {
+                                    "telemetry": {
+                                      "type": "String",
+                                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "cMKKeyVault": {
+                              "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId')))]",
+                              "existing": true,
+                              "type": "Microsoft.KeyVault/vaults",
+                              "apiVersion": "2024-11-01",
+                              "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+                              "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+                              "name": "[last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/'))]"
+                            },
+                            "cMKUserAssignedIdentity": {
+                              "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId')))]",
+                              "existing": true,
+                              "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+                              "apiVersion": "2024-11-30",
+                              "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[2]]",
+                              "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[4]]",
+                              "name": "[last(split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/'))]"
+                            },
+                            "registry": {
+                              "type": "Microsoft.ContainerRegistry/registries",
+                              "apiVersion": "2025-06-01-preview",
+                              "name": "[parameters('name')]",
+                              "location": "[parameters('location')]",
+                              "identity": "[variables('identity')]",
+                              "tags": "[parameters('tags')]",
+                              "sku": {
+                                "name": "[parameters('acrSku')]"
+                              },
+                              "properties": {
+                                "anonymousPullEnabled": "[parameters('anonymousPullEnabled')]",
+                                "adminUserEnabled": "[parameters('acrAdminUserEnabled')]",
+                                "autoGeneratedDomainNameLabelScope": "[parameters('autoGeneratedDomainNameLabelScope')]",
+                                "roleAssignmentMode": "[parameters('roleAssignmentMode')]",
+                                "encryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('status', 'enabled', 'keyVaultProperties', createObject('identity', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), ''))), reference('cMKUserAssignedIdentity').clientId, null()), 'keyIdentifier', if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion')), if(coalesce(tryGet(parameters('customerManagedKey'), 'autoRotationEnabled'), true()), reference('cMKKeyVault::cMKKey').keyUri, reference('cMKKeyVault::cMKKey').keyUriWithVersion)))), null())]",
+                                "policies": {
+                                  "azureADAuthenticationAsArmPolicy": {
+                                    "status": "[parameters('azureADAuthenticationAsArmPolicyStatus')]"
+                                  },
+                                  "exportPolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('status', parameters('exportPolicyStatus')), null())]",
+                                  "quarantinePolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('status', parameters('quarantinePolicyStatus')), null())]",
+                                  "trustPolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('type', 'Notary', 'status', parameters('trustPolicyStatus')), null())]",
+                                  "retentionPolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('days', parameters('retentionPolicyDays'), 'status', parameters('retentionPolicyStatus')), null())]",
+                                  "softDeletePolicy": {
+                                    "retentionDays": "[parameters('softDeletePolicyDays')]",
+                                    "status": "[parameters('softDeletePolicyStatus')]"
+                                  }
+                                },
+                                "dataEndpointEnabled": "[parameters('dataEndpointEnabled')]",
+                                "publicNetworkAccess": "[variables('publicNetworkAccessMode')]",
+                                "networkRuleBypassOptions": "[parameters('networkRuleBypassOptions')]",
+                                "networkRuleSet": "[if(variables('shouldConfigureNetworkRuleSet'), createObject('defaultAction', parameters('networkRuleSetDefaultAction'), 'ipRules', coalesce(parameters('networkRuleSetIpRules'), createArray())), null())]",
+                                "zoneRedundancy": "[if(equals(parameters('acrSku'), 'Premium'), parameters('zoneRedundancy'), null())]"
+                              },
+                              "dependsOn": [
+                                "cMKKeyVault::cMKKey",
+                                "cMKUserAssignedIdentity"
+                              ]
+                            },
+                            "registry_lock": {
+                              "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                              "type": "Microsoft.Authorization/locks",
+                              "apiVersion": "2020-05-01",
+                              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]",
+                              "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                              "properties": {
+                                "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                                "notes": "[coalesce(tryGet(parameters('lock'), 'notes'), if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.'))]"
+                              },
+                              "dependsOn": [
+                                "registry"
+                              ]
+                            },
+                            "registry_diagnosticSettings": {
+                              "copy": {
+                                "name": "registry_diagnosticSettings",
+                                "count": "[length(coalesce(parameters('diagnosticSettings'), createArray()))]"
+                              },
+                              "type": "Microsoft.Insights/diagnosticSettings",
+                              "apiVersion": "2021-05-01-preview",
+                              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]",
+                              "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
+                              "properties": {
+                                "copy": [
+                                  {
+                                    "name": "metrics",
+                                    "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups')), createArray(createObject('category', 'AllMetrics')), createArray())))]",
+                                    "input": {
+                                      "category": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups')), createArray(createObject('category', 'AllMetrics')), createArray()))[copyIndex('metrics')].category]",
+                                      "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups')), createArray(createObject('category', 'AllMetrics')), createArray()))[copyIndex('metrics')], 'enabled'), true())]",
+                                      "timeGrain": null
+                                    }
+                                  },
+                                  {
+                                    "name": "logs",
+                                    "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories')), createArray(createObject('categoryGroup', 'allLogs')), createArray())))]",
+                                    "input": {
+                                      "categoryGroup": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories')), createArray(createObject('categoryGroup', 'allLogs')), createArray()))[copyIndex('logs')], 'categoryGroup')]",
+                                      "category": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories')), createArray(createObject('categoryGroup', 'allLogs')), createArray()))[copyIndex('logs')], 'category')]",
+                                      "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), if(empty(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories')), createArray(createObject('categoryGroup', 'allLogs')), createArray()))[copyIndex('logs')], 'enabled'), true())]"
+                                    }
+                                  }
+                                ],
+                                "storageAccountId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'storageAccountResourceId')]",
+                                "workspaceId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'workspaceResourceId')]",
+                                "eventHubAuthorizationRuleId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubAuthorizationRuleResourceId')]",
+                                "eventHubName": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubName')]",
+                                "marketplacePartnerId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'marketplacePartnerResourceId')]",
+                                "logAnalyticsDestinationType": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logAnalyticsDestinationType')]"
+                              },
+                              "dependsOn": [
+                                "registry"
+                              ]
+                            },
+                            "registry_roleAssignments": {
+                              "copy": {
+                                "name": "registry_roleAssignments",
+                                "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                              },
+                              "type": "Microsoft.Authorization/roleAssignments",
+                              "apiVersion": "2022-04-01",
+                              "scope": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]",
+                              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                              "properties": {
+                                "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                                "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                                "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                                "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                                "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                                "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                                "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                              },
+                              "dependsOn": [
+                                "registry"
+                              ]
+                            },
+                            "registry_scopeMaps": {
+                              "copy": {
+                                "name": "registry_scopeMaps",
+                                "count": "[length(coalesce(parameters('scopeMaps'), createArray()))]"
+                              },
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('{0}-Registry-Scope-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "name": {
+                                    "value": "[tryGet(coalesce(parameters('scopeMaps'), createArray())[copyIndex()], 'name')]"
+                                  },
+                                  "actions": {
+                                    "value": "[coalesce(parameters('scopeMaps'), createArray())[copyIndex()].actions]"
+                                  },
+                                  "description": {
+                                    "value": "[tryGet(coalesce(parameters('scopeMaps'), createArray())[copyIndex()], 'description')]"
+                                  },
+                                  "registryName": {
+                                    "value": "[parameters('name')]"
+                                  },
+                                  "enableTelemetry": {
+                                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.0",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.42.1.51946",
+                                      "templateHash": "3787322352564227867"
+                                    },
+                                    "name": "Container Registries scope maps",
+                                    "description": "This module deploys an Azure Container Registry (ACR) scope map."
+                                  },
+                                  "parameters": {
+                                    "registryName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "defaultValue": "[format('{0}-scopemaps', parameters('registryName'))]",
+                                      "metadata": {
+                                        "description": "Optional. The name of the scope map."
+                                      }
+                                    },
+                                    "actions": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "metadata": {
+                                        "description": "Required. The list of scoped permissions for registry artifacts."
+                                      }
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. The user friendly description of the scope map."
+                                      }
+                                    },
+                                    "enableTelemetry": {
+                                      "type": "bool",
+                                      "defaultValue": true,
+                                      "metadata": {
+                                        "description": "Optional. Enable/Disable usage telemetry for module."
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "avmTelemetry": {
+                                      "condition": "[parameters('enableTelemetry')]",
+                                      "type": "Microsoft.Resources/deployments",
+                                      "apiVersion": "2025-04-01",
+                                      "name": "[format('46d3xbcp.res.containerregistry-registry-scopemap.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                                      "properties": {
+                                        "mode": "Incremental",
+                                        "template": {
+                                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                          "contentVersion": "1.0.0.0",
+                                          "resources": [],
+                                          "outputs": {
+                                            "telemetry": {
+                                              "type": "String",
+                                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "registry": {
+                                      "existing": true,
+                                      "type": "Microsoft.ContainerRegistry/registries",
+                                      "apiVersion": "2025-11-01",
+                                      "name": "[parameters('registryName')]"
+                                    },
+                                    "scopeMap": {
+                                      "type": "Microsoft.ContainerRegistry/registries/scopeMaps",
+                                      "apiVersion": "2025-11-01",
+                                      "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                                      "properties": {
+                                        "actions": "[parameters('actions')]",
+                                        "description": "[parameters('description')]"
+                                      }
+                                    }
+                                  },
+                                  "outputs": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the scope map."
+                                      },
+                                      "value": "[parameters('name')]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the resource group the scope map was created in."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the scope map."
+                                      },
+                                      "value": "[resourceId('Microsoft.ContainerRegistry/registries/scopeMaps', parameters('registryName'), parameters('name'))]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "registry"
+                              ]
+                            },
+                            "registry_replications": {
+                              "copy": {
+                                "name": "registry_replications",
+                                "count": "[length(coalesce(parameters('replications'), createArray()))]"
+                              },
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('{0}-Registry-Replication-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "name": {
+                                    "value": "[coalesce(parameters('replications'), createArray())[copyIndex()].name]"
+                                  },
+                                  "registryName": {
+                                    "value": "[parameters('name')]"
+                                  },
+                                  "location": {
+                                    "value": "[coalesce(parameters('replications'), createArray())[copyIndex()].location]"
+                                  },
+                                  "regionEndpointEnabled": {
+                                    "value": "[tryGet(coalesce(parameters('replications'), createArray())[copyIndex()], 'regionEndpointEnabled')]"
+                                  },
+                                  "zoneRedundancy": {
+                                    "value": "[tryGet(coalesce(parameters('replications'), createArray())[copyIndex()], 'zoneRedundancy')]"
+                                  },
+                                  "tags": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('replications'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                                  },
+                                  "enableTelemetry": {
+                                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.0",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.42.1.51946",
+                                      "templateHash": "6219097750044645017"
+                                    },
+                                    "name": "Azure Container Registry (ACR) Replications",
+                                    "description": "This module deploys an Azure Container Registry (ACR) Replication."
+                                  },
+                                  "parameters": {
+                                    "registryName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The name of the replication."
+                                      }
+                                    },
+                                    "location": {
+                                      "type": "string",
+                                      "defaultValue": "[resourceGroup().location]",
+                                      "metadata": {
+                                        "description": "Optional. Location for all resources."
+                                      }
+                                    },
+                                    "tags": {
+                                      "type": "object",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.ContainerRegistry/registries/replications@2025-11-01#properties/tags"
+                                        },
+                                        "description": "Optional. Tags of the resource."
+                                      },
+                                      "nullable": true
+                                    },
+                                    "regionEndpointEnabled": {
+                                      "type": "bool",
+                                      "defaultValue": true,
+                                      "metadata": {
+                                        "description": "Optional. Specifies whether the replication regional endpoint is enabled. Requests will not be routed to a replication whose regional endpoint is disabled, however its data will continue to be synced with other replications."
+                                      }
+                                    },
+                                    "zoneRedundancy": {
+                                      "type": "string",
+                                      "defaultValue": "Disabled",
+                                      "allowedValues": [
+                                        "Disabled",
+                                        "Enabled"
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. Whether or not zone redundancy is enabled for this container registry."
+                                      }
+                                    },
+                                    "enableTelemetry": {
+                                      "type": "bool",
+                                      "defaultValue": true,
+                                      "metadata": {
+                                        "description": "Optional. Enable/Disable usage telemetry for module."
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "avmTelemetry": {
+                                      "condition": "[parameters('enableTelemetry')]",
+                                      "type": "Microsoft.Resources/deployments",
+                                      "apiVersion": "2025-04-01",
+                                      "name": "[format('46d3xbcp.res.containerregistry-registry-repl.{0}.{1}', replace('0.1.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                                      "properties": {
+                                        "mode": "Incremental",
+                                        "template": {
+                                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                          "contentVersion": "1.0.0.0",
+                                          "resources": [],
+                                          "outputs": {
+                                            "telemetry": {
+                                              "type": "String",
+                                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "registry": {
+                                      "existing": true,
+                                      "type": "Microsoft.ContainerRegistry/registries",
+                                      "apiVersion": "2025-11-01",
+                                      "name": "[parameters('registryName')]"
+                                    },
+                                    "replication": {
+                                      "type": "Microsoft.ContainerRegistry/registries/replications",
+                                      "apiVersion": "2025-11-01",
+                                      "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                                      "location": "[parameters('location')]",
+                                      "tags": "[parameters('tags')]",
+                                      "properties": {
+                                        "regionEndpointEnabled": "[parameters('regionEndpointEnabled')]",
+                                        "zoneRedundancy": "[parameters('zoneRedundancy')]"
+                                      }
+                                    }
+                                  },
+                                  "outputs": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the replication."
+                                      },
+                                      "value": "[parameters('name')]"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the replication."
+                                      },
+                                      "value": "[resourceId('Microsoft.ContainerRegistry/registries/replications', parameters('registryName'), parameters('name'))]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the resource group the replication was created in."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    },
+                                    "location": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The location the resource was deployed into."
+                                      },
+                                      "value": "[reference('replication', '2025-11-01', 'full').location]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "registry"
+                              ]
+                            },
+                            "registry_credentialSets": {
+                              "copy": {
+                                "name": "registry_credentialSets",
+                                "count": "[length(coalesce(parameters('credentialSets'), createArray()))]"
+                              },
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('{0}-Registry-CredentialSet-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "name": {
+                                    "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].name]"
+                                  },
+                                  "registryName": {
+                                    "value": "[parameters('name')]"
+                                  },
+                                  "managedIdentities": {
+                                    "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].managedIdentities]"
+                                  },
+                                  "authCredentials": {
+                                    "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].authCredentials]"
+                                  },
+                                  "loginServer": {
+                                    "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].loginServer]"
+                                  },
+                                  "enableTelemetry": {
+                                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.0",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.42.1.51946",
+                                      "templateHash": "13412699468141336519"
+                                    },
+                                    "name": "Container Registries Credential Sets",
+                                    "description": "This module deploys an ACR Credential Set."
+                                  },
+                                  "definitions": {
+                                    "authCredentialsType": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "metadata": {
+                                            "description": "Required. The name of the credential."
+                                          }
+                                        },
+                                        "usernameSecretIdentifier": {
+                                          "type": "string",
+                                          "metadata": {
+                                            "description": "Required. KeyVault Secret URI for accessing the username."
+                                          }
+                                        },
+                                        "passwordSecretIdentifier": {
+                                          "type": "string",
+                                          "metadata": {
+                                            "description": "Required. KeyVault Secret URI for accessing the password."
+                                          }
+                                        }
+                                      },
+                                      "metadata": {
+                                        "__bicep_export!": true,
+                                        "description": "The type for auth credentials."
+                                      }
+                                    },
+                                    "managedIdentityOnlySysAssignedType": {
+                                      "type": "object",
+                                      "properties": {
+                                        "systemAssigned": {
+                                          "type": "bool",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. Enables system assigned managed identity on the resource."
+                                          }
+                                        }
+                                      },
+                                      "metadata": {
+                                        "description": "An AVM-aligned type for a managed identity configuration. To be used if only system-assigned identities are supported by the resource provider.",
+                                        "__bicep_imported_from!": {
+                                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "parameters": {
+                                    "registryName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The name of the credential set."
+                                      }
+                                    },
+                                    "managedIdentities": {
+                                      "$ref": "#/definitions/managedIdentityOnlySysAssignedType",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. The managed identity definition for this resource."
+                                      }
+                                    },
+                                    "authCredentials": {
+                                      "type": "array",
+                                      "items": {
+                                        "$ref": "#/definitions/authCredentialsType"
+                                      },
+                                      "metadata": {
+                                        "description": "Required. List of authentication credentials stored for an upstream. Usually consists of a primary and an optional secondary credential."
+                                      }
+                                    },
+                                    "loginServer": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The credentials are stored for this upstream or login server."
+                                      }
+                                    },
+                                    "enableTelemetry": {
+                                      "type": "bool",
+                                      "defaultValue": true,
+                                      "metadata": {
+                                        "description": "Optional. Enable/Disable usage telemetry for module."
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "avmTelemetry": {
+                                      "condition": "[parameters('enableTelemetry')]",
+                                      "type": "Microsoft.Resources/deployments",
+                                      "apiVersion": "2025-04-01",
+                                      "name": "[format('46d3xbcp.res.containerregistry-registry-credset.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                                      "properties": {
+                                        "mode": "Incremental",
+                                        "template": {
+                                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                          "contentVersion": "1.0.0.0",
+                                          "resources": [],
+                                          "outputs": {
+                                            "telemetry": {
+                                              "type": "String",
+                                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "registry": {
+                                      "existing": true,
+                                      "type": "Microsoft.ContainerRegistry/registries",
+                                      "apiVersion": "2025-11-01",
+                                      "name": "[parameters('registryName')]"
+                                    },
+                                    "credentialSet": {
+                                      "type": "Microsoft.ContainerRegistry/registries/credentialSets",
+                                      "apiVersion": "2025-11-01",
+                                      "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                                      "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), 'SystemAssigned', null())), null())]",
+                                      "properties": {
+                                        "authCredentials": "[parameters('authCredentials')]",
+                                        "loginServer": "[parameters('loginServer')]"
+                                      }
+                                    }
+                                  },
+                                  "outputs": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The Name of the Credential Set."
+                                      },
+                                      "value": "[parameters('name')]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the Credential Set."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the Credential Set."
+                                      },
+                                      "value": "[resourceId('Microsoft.ContainerRegistry/registries/credentialSets', parameters('registryName'), parameters('name'))]"
+                                    },
+                                    "systemAssignedMIPrincipalId": {
+                                      "type": "string",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "The principal ID of the system assigned identity."
+                                      },
+                                      "value": "[tryGet(tryGet(reference('credentialSet', '2025-11-01', 'full'), 'identity'), 'principalId')]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "registry"
+                              ]
+                            },
+                            "registry_cacheRules": {
+                              "copy": {
+                                "name": "registry_cacheRules",
+                                "count": "[length(coalesce(parameters('cacheRules'), createArray()))]"
+                              },
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('{0}-Registry-Cache-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "registryName": {
+                                    "value": "[parameters('name')]"
+                                  },
+                                  "sourceRepository": {
+                                    "value": "[coalesce(parameters('cacheRules'), createArray())[copyIndex()].sourceRepository]"
+                                  },
+                                  "name": {
+                                    "value": "[tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'name')]"
+                                  },
+                                  "targetRepository": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'targetRepository'), coalesce(parameters('cacheRules'), createArray())[copyIndex()].sourceRepository)]"
+                                  },
+                                  "credentialSetResourceId": {
+                                    "value": "[tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'credentialSetResourceId')]"
+                                  },
+                                  "enableTelemetry": {
+                                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.0",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.42.1.51946",
+                                      "templateHash": "1319901650921923538"
+                                    },
+                                    "name": "Container Registry Cache",
+                                    "description": "The cache for Azure Container Registry (Preview) feature allows users to cache container images in a private container registry. Cache for ACR, is a preview feature available in Basic, Standard, and Premium service tiers ([ref](https://learn.microsoft.com/en-us/azure/container-registry/tutorial-registry-cache))."
+                                  },
+                                  "parameters": {
+                                    "registryName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "defaultValue": "[replace(replace(replace(parameters('sourceRepository'), '/', '-'), '.', '-'), '*', '')]",
+                                      "metadata": {
+                                        "description": "Optional. The name of the cache rule. Will be derived from the source repository name if not defined."
+                                      }
+                                    },
+                                    "sourceRepository": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. Source repository pulled from upstream."
+                                      }
+                                    },
+                                    "targetRepository": {
+                                      "type": "string",
+                                      "defaultValue": "[parameters('sourceRepository')]",
+                                      "metadata": {
+                                        "description": "Optional. Target repository specified in docker pull command. E.g.: docker pull myregistry.azurecr.io/{targetRepository}:{tag}."
+                                      }
+                                    },
+                                    "credentialSetResourceId": {
+                                      "type": "string",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. The resource ID of the credential store which is associated with the cache rule. Required only when pulling from authenticated upstream registries (e.g., Docker Hub). Omit for anonymous public registries such as MCR (mcr.microsoft.com)."
+                                      }
+                                    },
+                                    "enableTelemetry": {
+                                      "type": "bool",
+                                      "defaultValue": true,
+                                      "metadata": {
+                                        "description": "Optional. Enable/Disable usage telemetry for module."
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "avmTelemetry": {
+                                      "condition": "[parameters('enableTelemetry')]",
+                                      "type": "Microsoft.Resources/deployments",
+                                      "apiVersion": "2025-04-01",
+                                      "name": "[format('46d3xbcp.res.containerregistry-registry-cacherule.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                                      "properties": {
+                                        "mode": "Incremental",
+                                        "template": {
+                                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                          "contentVersion": "1.0.0.0",
+                                          "resources": [],
+                                          "outputs": {
+                                            "telemetry": {
+                                              "type": "String",
+                                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "registry": {
+                                      "existing": true,
+                                      "type": "Microsoft.ContainerRegistry/registries",
+                                      "apiVersion": "2025-11-01",
+                                      "name": "[parameters('registryName')]"
+                                    },
+                                    "cacheRule": {
+                                      "type": "Microsoft.ContainerRegistry/registries/cacheRules",
+                                      "apiVersion": "2025-11-01",
+                                      "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                                      "properties": {
+                                        "sourceRepository": "[parameters('sourceRepository')]",
+                                        "targetRepository": "[parameters('targetRepository')]",
+                                        "credentialSetResourceId": "[parameters('credentialSetResourceId')]"
+                                      }
+                                    }
+                                  },
+                                  "outputs": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The Name of the Cache Rule."
+                                      },
+                                      "value": "[parameters('name')]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the Cache Rule."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the Cache Rule."
+                                      },
+                                      "value": "[resourceId('Microsoft.ContainerRegistry/registries/cacheRules', parameters('registryName'), parameters('name'))]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "registry",
+                                "registry_credentialSets"
+                              ]
+                            },
+                            "registry_tokens": {
+                              "copy": {
+                                "name": "registry_tokens",
+                                "count": "[length(coalesce(parameters('tokens'), createArray()))]"
+                              },
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('{0}-Registry-Token-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "name": {
+                                    "value": "[coalesce(parameters('tokens'), createArray())[copyIndex()].name]"
+                                  },
+                                  "registryName": {
+                                    "value": "[parameters('name')]"
+                                  },
+                                  "scopeMapResourceId": {
+                                    "value": "[coalesce(parameters('tokens'), createArray())[copyIndex()].scopeMapResourceId]"
+                                  },
+                                  "status": {
+                                    "value": "[tryGet(coalesce(parameters('tokens'), createArray())[copyIndex()], 'status')]"
+                                  },
+                                  "credentials": {
+                                    "value": "[tryGet(coalesce(parameters('tokens'), createArray())[copyIndex()], 'credentials')]"
+                                  },
+                                  "enableTelemetry": {
+                                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.0",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.42.1.51946",
+                                      "templateHash": "5970335582661416899"
+                                    },
+                                    "name": "Container Registries Tokens",
+                                    "description": "Deploys an Azure Container Registry (ACR) Token."
+                                  },
+                                  "parameters": {
+                                    "registryName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "minLength": 5,
+                                      "maxLength": 50,
+                                      "metadata": {
+                                        "description": "Required. The name of the token."
+                                      }
+                                    },
+                                    "scopeMapResourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The resource ID of the scope map to which the token will be associated with."
+                                      }
+                                    },
+                                    "status": {
+                                      "type": "string",
+                                      "defaultValue": "enabled",
+                                      "allowedValues": [
+                                        "disabled",
+                                        "enabled"
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. The status of the token. Default is enabled."
+                                      }
+                                    },
+                                    "credentials": {
+                                      "type": "object",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.ContainerRegistry/registries/tokens@2025-11-01#properties/properties/properties/credentials"
+                                        },
+                                        "description": "Optional. The credentials associated with the token for authentication."
+                                      },
+                                      "nullable": true
+                                    },
+                                    "enableTelemetry": {
+                                      "type": "bool",
+                                      "defaultValue": true,
+                                      "metadata": {
+                                        "description": "Optional. Enable/Disable usage telemetry for module."
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "avmTelemetry": {
+                                      "condition": "[parameters('enableTelemetry')]",
+                                      "type": "Microsoft.Resources/deployments",
+                                      "apiVersion": "2025-04-01",
+                                      "name": "[format('46d3xbcp.res.containerregistry-registry-token.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name), 0, 4))]",
+                                      "properties": {
+                                        "mode": "Incremental",
+                                        "template": {
+                                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                          "contentVersion": "1.0.0.0",
+                                          "resources": [],
+                                          "outputs": {
+                                            "telemetry": {
+                                              "type": "String",
+                                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "registry": {
+                                      "existing": true,
+                                      "type": "Microsoft.ContainerRegistry/registries",
+                                      "apiVersion": "2025-11-01",
+                                      "name": "[parameters('registryName')]"
+                                    },
+                                    "token": {
+                                      "type": "Microsoft.ContainerRegistry/registries/tokens",
+                                      "apiVersion": "2025-11-01",
+                                      "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                                      "properties": {
+                                        "scopeMapId": "[parameters('scopeMapResourceId')]",
+                                        "status": "[parameters('status')]",
+                                        "credentials": "[if(not(empty(coalesce(parameters('credentials'), createArray()))), createObject('certificates', tryGet(parameters('credentials'), 'certificates'), 'passwords', tryGet(parameters('credentials'), 'passwords')), null())]"
+                                      }
+                                    }
+                                  },
+                                  "outputs": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the token."
+                                      },
+                                      "value": "[parameters('name')]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the resource group the token was created in."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the token."
+                                      },
+                                      "value": "[resourceId('Microsoft.ContainerRegistry/registries/tokens', parameters('registryName'), parameters('name'))]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "registry",
+                                "registry_scopeMaps"
+                              ]
+                            },
+                            "registry_tasks": {
+                              "copy": {
+                                "name": "registry_tasks",
+                                "count": "[length(coalesce(parameters('tasks'), createArray()))]"
+                              },
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('{0}-Registry-Task-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "registryName": {
+                                    "value": "[parameters('name')]"
+                                  },
+                                  "name": {
+                                    "value": "[coalesce(parameters('tasks'), createArray())[copyIndex()].name]"
+                                  },
+                                  "location": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'location'), parameters('location'))]"
+                                  },
+                                  "tags": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                                  },
+                                  "platform": {
+                                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'platform')]"
+                                  },
+                                  "step": {
+                                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'step')]"
+                                  },
+                                  "trigger": {
+                                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'trigger')]"
+                                  },
+                                  "status": {
+                                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'status')]"
+                                  },
+                                  "timeout": {
+                                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'timeout')]"
+                                  },
+                                  "agentConfiguration": {
+                                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'agentConfiguration')]"
+                                  },
+                                  "agentPoolName": {
+                                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'agentPoolName')]"
+                                  },
+                                  "credentials": {
+                                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'credentials')]"
+                                  },
+                                  "isSystemTask": {
+                                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'isSystemTask')]"
+                                  },
+                                  "logTemplate": {
+                                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'logTemplate')]"
+                                  },
+                                  "managedIdentities": {
+                                    "value": "[tryGet(coalesce(parameters('tasks'), createArray())[copyIndex()], 'managedIdentities')]"
+                                  },
+                                  "enableTelemetry": {
+                                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.0",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.42.1.51946",
+                                      "templateHash": "2468771835002458415"
+                                    },
+                                    "name": "Container Registries Tasks",
+                                    "description": "Deploys an Azure Container Registry (ACR) Task that can be used to automate container image builds and other workflows ([ref](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-tasks-overview))."
+                                  },
+                                  "definitions": {
+                                    "managedIdentityAllType": {
+                                      "type": "object",
+                                      "properties": {
+                                        "systemAssigned": {
+                                          "type": "bool",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. Enables system assigned managed identity on the resource."
+                                          }
+                                        },
+                                        "userAssignedResourceIds": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. The resource ID(s) to assign to the resource. Required if a user assigned identity is used for encryption."
+                                          }
+                                        }
+                                      },
+                                      "metadata": {
+                                        "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
+                                        "__bicep_imported_from!": {
+                                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "parameters": {
+                                    "registryName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "minLength": 5,
+                                      "maxLength": 50,
+                                      "metadata": {
+                                        "description": "Required. The name of the task."
+                                      }
+                                    },
+                                    "location": {
+                                      "type": "string",
+                                      "defaultValue": "[resourceGroup().location]",
+                                      "metadata": {
+                                        "description": "Optional. Location for all resources."
+                                      }
+                                    },
+                                    "tags": {
+                                      "type": "object",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/tags"
+                                        },
+                                        "description": "Optional. Tags of the resource."
+                                      },
+                                      "nullable": true
+                                    },
+                                    "platform": {
+                                      "type": "object",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/platform"
+                                        },
+                                        "description": "Optional. The platform properties against which the task has to run."
+                                      },
+                                      "nullable": true
+                                    },
+                                    "step": {
+                                      "type": "object",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/step"
+                                        },
+                                        "description": "Optional. The task step properties. Exactly one of dockerBuildStep, encodedTaskStep, or fileTaskStep must be provided."
+                                      },
+                                      "nullable": true
+                                    },
+                                    "trigger": {
+                                      "type": "object",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/trigger"
+                                        },
+                                        "description": "Optional. The properties that describe all triggers for the task."
+                                      },
+                                      "nullable": true
+                                    },
+                                    "status": {
+                                      "type": "string",
+                                      "defaultValue": "Enabled",
+                                      "allowedValues": [
+                                        "Disabled",
+                                        "Enabled"
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. The current status of task."
+                                      }
+                                    },
+                                    "timeout": {
+                                      "type": "int",
+                                      "defaultValue": 3600,
+                                      "minValue": 300,
+                                      "maxValue": 28800,
+                                      "metadata": {
+                                        "description": "Optional. Run timeout in seconds."
+                                      }
+                                    },
+                                    "agentConfiguration": {
+                                      "type": "object",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/agentConfiguration"
+                                        },
+                                        "description": "Optional. The machine configuration of the run agent."
+                                      },
+                                      "nullable": true
+                                    },
+                                    "agentPoolName": {
+                                      "type": "string",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. The dedicated agent pool for the task."
+                                      }
+                                    },
+                                    "credentials": {
+                                      "type": "object",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.ContainerRegistry/registries/tasks@2025-03-01-preview#properties/properties/properties/credentials"
+                                        },
+                                        "description": "Optional. The properties that describe the credentials that will be used when the task is invoked."
+                                      },
+                                      "nullable": true
+                                    },
+                                    "isSystemTask": {
+                                      "type": "bool",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. The value of this property indicates whether the task resource is system task or not."
+                                      }
+                                    },
+                                    "logTemplate": {
+                                      "type": "string",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. The template that describes the repository and tag information for run log artifact."
+                                      }
+                                    },
+                                    "managedIdentities": {
+                                      "$ref": "#/definitions/managedIdentityAllType",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. The managed identity definition for this resource."
+                                      }
+                                    },
+                                    "enableTelemetry": {
+                                      "type": "bool",
+                                      "defaultValue": true,
+                                      "metadata": {
+                                        "description": "Optional. Enable/Disable usage telemetry for module."
+                                      }
+                                    }
+                                  },
+                                  "variables": {
+                                    "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
+                                    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned, UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]"
+                                  },
+                                  "resources": {
+                                    "avmTelemetry": {
+                                      "condition": "[parameters('enableTelemetry')]",
+                                      "type": "Microsoft.Resources/deployments",
+                                      "apiVersion": "2025-04-01",
+                                      "name": "[format('46d3xbcp.res.containerregistry-registry-task.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                                      "properties": {
+                                        "mode": "Incremental",
+                                        "template": {
+                                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                          "contentVersion": "1.0.0.0",
+                                          "resources": [],
+                                          "outputs": {
+                                            "telemetry": {
+                                              "type": "String",
+                                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "registry": {
+                                      "existing": true,
+                                      "type": "Microsoft.ContainerRegistry/registries",
+                                      "apiVersion": "2025-11-01",
+                                      "name": "[parameters('registryName')]"
+                                    },
+                                    "task": {
+                                      "type": "Microsoft.ContainerRegistry/registries/tasks",
+                                      "apiVersion": "2025-03-01-preview",
+                                      "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                                      "location": "[parameters('location')]",
+                                      "identity": "[variables('identity')]",
+                                      "tags": "[parameters('tags')]",
+                                      "properties": {
+                                        "agentConfiguration": "[parameters('agentConfiguration')]",
+                                        "agentPoolName": "[parameters('agentPoolName')]",
+                                        "credentials": "[parameters('credentials')]",
+                                        "isSystemTask": "[parameters('isSystemTask')]",
+                                        "logTemplate": "[parameters('logTemplate')]",
+                                        "platform": "[parameters('platform')]",
+                                        "status": "[parameters('status')]",
+                                        "step": "[parameters('step')]",
+                                        "timeout": "[parameters('timeout')]",
+                                        "trigger": "[parameters('trigger')]"
+                                      }
+                                    }
+                                  },
+                                  "outputs": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the task."
+                                      },
+                                      "value": "[parameters('name')]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the resource group the task was deployed into."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the task."
+                                      },
+                                      "value": "[resourceId('Microsoft.ContainerRegistry/registries/tasks', parameters('registryName'), parameters('name'))]"
+                                    },
+                                    "location": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The location the resource was deployed into."
+                                      },
+                                      "value": "[reference('task', '2025-03-01-preview', 'full').location]"
+                                    },
+                                    "systemAssignedMIPrincipalId": {
+                                      "type": "string",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "The principal ID of the system assigned identity."
+                                      },
+                                      "value": "[tryGet(tryGet(reference('task', '2025-03-01-preview', 'full'), 'identity'), 'principalId')]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "registry"
+                              ]
+                            },
+                            "registry_webhooks": {
+                              "copy": {
+                                "name": "registry_webhooks",
+                                "count": "[length(coalesce(parameters('webhooks'), createArray()))]"
+                              },
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('{0}-Registry-Webhook-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "name": {
+                                    "value": "[coalesce(parameters('webhooks'), createArray())[copyIndex()].name]"
+                                  },
+                                  "registryName": {
+                                    "value": "[parameters('name')]"
+                                  },
+                                  "location": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'location'), parameters('location'))]"
+                                  },
+                                  "action": {
+                                    "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'action')]"
+                                  },
+                                  "customHeaders": {
+                                    "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'customHeaders')]"
+                                  },
+                                  "scope": {
+                                    "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'scope')]"
+                                  },
+                                  "status": {
+                                    "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'status')]"
+                                  },
+                                  "serviceUri": {
+                                    "value": "[coalesce(parameters('webhooks'), createArray())[copyIndex()].serviceUri]"
+                                  },
+                                  "tags": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                                  },
+                                  "enableTelemetry": {
+                                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.0",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.42.1.51946",
+                                      "templateHash": "3200175097987099858"
+                                    },
+                                    "name": "Azure Container Registry (ACR) Webhooks",
+                                    "description": "This module deploys an Azure Container Registry (ACR) Webhook."
+                                  },
+                                  "parameters": {
+                                    "registryName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "defaultValue": "[format('{0}webhook', parameters('registryName'))]",
+                                      "minLength": 5,
+                                      "maxLength": 50,
+                                      "metadata": {
+                                        "description": "Optional. The name of the registry webhook."
+                                      }
+                                    },
+                                    "serviceUri": {
+                                      "type": "securestring",
+                                      "metadata": {
+                                        "description": "Required. The service URI for the webhook to post notifications."
+                                      }
+                                    },
+                                    "status": {
+                                      "type": "string",
+                                      "defaultValue": "enabled",
+                                      "allowedValues": [
+                                        "disabled",
+                                        "enabled"
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. The status of the webhook at the time the operation was called."
+                                      }
+                                    },
+                                    "action": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "defaultValue": [
+                                        "chart_delete",
+                                        "chart_push",
+                                        "delete",
+                                        "push",
+                                        "quarantine"
+                                      ],
+                                      "metadata": {
+                                        "description": "Optional. The list of actions that trigger the webhook to post notifications."
+                                      }
+                                    },
+                                    "location": {
+                                      "type": "string",
+                                      "defaultValue": "[resourceGroup().location]",
+                                      "metadata": {
+                                        "description": "Optional. Location for all resources."
+                                      }
+                                    },
+                                    "tags": {
+                                      "type": "object",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.ContainerRegistry/registries/webhooks@2025-11-01#properties/tags"
+                                        },
+                                        "description": "Optional. Tags of the resource."
+                                      },
+                                      "nullable": true
+                                    },
+                                    "customHeaders": {
+                                      "type": "object",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. Custom headers that will be added to the webhook notifications."
+                                      }
+                                    },
+                                    "scope": {
+                                      "type": "string",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. The scope of repositories where the event can be triggered. For example, 'foo:*' means events for all tags under repository 'foo'. 'foo:bar' means events for 'foo:bar' only. 'foo' is equivalent to 'foo:latest'. Empty means all events."
+                                      }
+                                    },
+                                    "enableTelemetry": {
+                                      "type": "bool",
+                                      "defaultValue": true,
+                                      "metadata": {
+                                        "description": "Optional. Enable/Disable usage telemetry for module."
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "avmTelemetry": {
+                                      "condition": "[parameters('enableTelemetry')]",
+                                      "type": "Microsoft.Resources/deployments",
+                                      "apiVersion": "2025-04-01",
+                                      "name": "[format('46d3xbcp.res.containerregistry-registry-webhook.{0}.{1}', replace('-..--..-', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                                      "properties": {
+                                        "mode": "Incremental",
+                                        "template": {
+                                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                          "contentVersion": "1.0.0.0",
+                                          "resources": [],
+                                          "outputs": {
+                                            "telemetry": {
+                                              "type": "String",
+                                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "registry": {
+                                      "existing": true,
+                                      "type": "Microsoft.ContainerRegistry/registries",
+                                      "apiVersion": "2025-11-01",
+                                      "name": "[parameters('registryName')]"
+                                    },
+                                    "webhook": {
+                                      "type": "Microsoft.ContainerRegistry/registries/webhooks",
+                                      "apiVersion": "2025-11-01",
+                                      "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                                      "location": "[parameters('location')]",
+                                      "tags": "[parameters('tags')]",
+                                      "properties": {
+                                        "actions": "[parameters('action')]",
+                                        "customHeaders": "[parameters('customHeaders')]",
+                                        "scope": "[parameters('scope')]",
+                                        "serviceUri": "[parameters('serviceUri')]",
+                                        "status": "[parameters('status')]"
+                                      }
+                                    }
+                                  },
+                                  "outputs": {
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the webhook."
+                                      },
+                                      "value": "[resourceId('Microsoft.ContainerRegistry/registries/webhooks', parameters('registryName'), parameters('name'))]"
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the webhook."
+                                      },
+                                      "value": "[parameters('name')]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the Azure container registry."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    },
+                                    "actions": {
+                                      "type": "array",
+                                      "metadata": {
+                                        "description": "The actions of the webhook."
+                                      },
+                                      "value": "[reference('webhook').actions]"
+                                    },
+                                    "status": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The status of the webhook."
+                                      },
+                                      "value": "[reference('webhook').status]"
+                                    },
+                                    "provistioningState": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The provisioning state of the webhook."
+                                      },
+                                      "value": "[reference('webhook').provisioningState]"
+                                    },
+                                    "location": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The location the resource was deployed into."
+                                      },
+                                      "value": "[reference('webhook', '2025-11-01', 'full').location]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "registry"
+                              ]
+                            },
+                            "registry_privateEndpoints": {
+                              "copy": {
+                                "name": "registry_privateEndpoints",
+                                "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]"
+                              },
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2025-04-01",
+                              "name": "[format('{0}-registry-PrivateEndpoint-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                              "subscriptionId": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[2]]",
+                              "resourceGroup": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[4]]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "name": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'name'), format('pep-{0}-{1}-{2}', last(split(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry'), copyIndex()))]"
+                                  },
+                                  "privateLinkServiceConnections": "[if(not(equals(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'isManualConnection'), true())), createObject('value', createArray(createObject('name', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateLinkServiceConnectionName'), format('{0}-{1}-{2}', last(split(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry'), copyIndex())), 'properties', createObject('privateLinkServiceId', resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), 'groupIds', createArray(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry')))))), createObject('value', null()))]",
+                                  "manualPrivateLinkServiceConnections": "[if(equals(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'isManualConnection'), true()), createObject('value', createArray(createObject('name', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateLinkServiceConnectionName'), format('{0}-{1}-{2}', last(split(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry'), copyIndex())), 'properties', createObject('privateLinkServiceId', resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), 'groupIds', createArray(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry')), 'requestMessage', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'manualConnectionRequestMessage'), 'Manual approval required.'))))), createObject('value', null()))]",
+                                  "subnetResourceId": {
+                                    "value": "[coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId]"
+                                  },
+                                  "enableTelemetry": {
+                                    "value": "[variables('enableReferencedModulesTelemetry')]"
+                                  },
+                                  "location": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'location'), reference(split(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location)]"
+                                  },
+                                  "lock": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'lock'), parameters('lock'))]"
+                                  },
+                                  "privateDnsZoneGroup": {
+                                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateDnsZoneGroup')]"
+                                  },
+                                  "roleAssignments": {
+                                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'roleAssignments')]"
+                                  },
+                                  "tags": {
+                                    "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                                  },
+                                  "customDnsConfigs": {
+                                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'customDnsConfigs')]"
+                                  },
+                                  "ipConfigurations": {
+                                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'ipConfigurations')]"
+                                  },
+                                  "applicationSecurityGroupResourceIds": {
+                                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'applicationSecurityGroupResourceIds')]"
+                                  },
+                                  "customNetworkInterfaceName": {
+                                    "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'customNetworkInterfaceName')]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.0",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.41.2.15936",
+                                      "templateHash": "18436885663402767850"
+                                    },
+                                    "name": "Private Endpoints",
+                                    "description": "This module deploys a Private Endpoint."
+                                  },
+                                  "definitions": {
+                                    "privateDnsZoneGroupType": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. The name of the Private DNS Zone Group."
+                                          }
+                                        },
+                                        "privateDnsZoneGroupConfigs": {
+                                          "type": "array",
+                                          "items": {
+                                            "$ref": "#/definitions/privateDnsZoneGroupConfigType"
+                                          },
+                                          "metadata": {
+                                            "description": "Required. The private DNS zone groups to associate the private endpoint. A DNS zone group can support up to 5 DNS zones."
+                                          }
+                                        }
+                                      },
+                                      "metadata": {
+                                        "__bicep_export!": true,
+                                        "description": "The type of a private dns zone group."
+                                      }
+                                    },
+                                    "lockType": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. Specify the name of lock."
+                                          }
+                                        },
+                                        "kind": {
+                                          "type": "string",
+                                          "allowedValues": [
+                                            "CanNotDelete",
+                                            "None",
+                                            "ReadOnly"
+                                          ],
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. Specify the type of lock."
+                                          }
+                                        },
+                                        "notes": {
+                                          "type": "string",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. Specify the notes of the lock."
+                                          }
+                                        }
+                                      },
+                                      "metadata": {
+                                        "description": "An AVM-aligned type for a lock.",
+                                        "__bicep_imported_from!": {
+                                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                        }
+                                      }
+                                    },
+                                    "privateDnsZoneGroupConfigType": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. The name of the private DNS zone group config."
+                                          }
+                                        },
+                                        "privateDnsZoneResourceId": {
+                                          "type": "string",
+                                          "metadata": {
+                                            "description": "Required. The resource id of the private DNS zone."
+                                          }
+                                        }
+                                      },
+                                      "metadata": {
+                                        "description": "The type of a private DNS zone group configuration.",
+                                        "__bicep_imported_from!": {
+                                          "sourceTemplate": "private-dns-zone-group/main.bicep"
+                                        }
+                                      }
+                                    },
+                                    "roleAssignmentType": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                                          }
+                                        },
+                                        "roleDefinitionIdOrName": {
+                                          "type": "string",
+                                          "metadata": {
+                                            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                                          }
+                                        },
+                                        "principalId": {
+                                          "type": "string",
+                                          "metadata": {
+                                            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                                          }
+                                        },
+                                        "principalType": {
+                                          "type": "string",
+                                          "allowedValues": [
+                                            "Device",
+                                            "ForeignGroup",
+                                            "Group",
+                                            "ServicePrincipal",
+                                            "User"
+                                          ],
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. The principal type of the assigned principal ID."
+                                          }
+                                        },
+                                        "description": {
+                                          "type": "string",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. The description of the role assignment."
+                                          }
+                                        },
+                                        "condition": {
+                                          "type": "string",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                                          }
+                                        },
+                                        "conditionVersion": {
+                                          "type": "string",
+                                          "allowedValues": [
+                                            "2.0"
+                                          ],
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. Version of the condition."
+                                          }
+                                        },
+                                        "delegatedManagedIdentityResourceId": {
+                                          "type": "string",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. The Resource Id of the delegated managed identity resource."
+                                          }
+                                        }
+                                      },
+                                      "metadata": {
+                                        "description": "An AVM-aligned type for a role assignment.",
+                                        "__bicep_imported_from!": {
+                                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "parameters": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. Name of the private endpoint resource to create."
+                                      }
+                                    },
+                                    "subnetResourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                                      }
+                                    },
+                                    "applicationSecurityGroupResourceIds": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. Application security groups in which the private endpoint IP configuration is included."
+                                      }
+                                    },
+                                    "customNetworkInterfaceName": {
+                                      "type": "string",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. The custom name of the network interface attached to the private endpoint."
+                                      }
+                                    },
+                                    "ipConfigurations": {
+                                      "type": "array",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/ipConfigurations"
+                                        },
+                                        "description": "Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints."
+                                      },
+                                      "nullable": true
+                                    },
+                                    "ipVersionType": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/ipVersionType"
+                                        },
+                                        "description": "Optional. Specifies the IP version type for the private IPs of the private endpoint. If not defined, this defaults to IPv4."
+                                      },
+                                      "defaultValue": "IPv4"
+                                    },
+                                    "privateDnsZoneGroup": {
+                                      "$ref": "#/definitions/privateDnsZoneGroupType",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. The private DNS zone group to configure for the private endpoint."
+                                      }
+                                    },
+                                    "location": {
+                                      "type": "string",
+                                      "defaultValue": "[resourceGroup().location]",
+                                      "metadata": {
+                                        "description": "Optional. Location for all Resources."
+                                      }
+                                    },
+                                    "lock": {
+                                      "$ref": "#/definitions/lockType",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. The lock settings of the service."
+                                      }
+                                    },
+                                    "roleAssignments": {
+                                      "type": "array",
+                                      "items": {
+                                        "$ref": "#/definitions/roleAssignmentType"
+                                      },
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. Array of role assignments to create."
+                                      }
+                                    },
+                                    "tags": {
+                                      "type": "object",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/tags"
+                                        },
+                                        "description": "Optional. Tags to be applied on all resources/resource groups in this deployment."
+                                      },
+                                      "nullable": true
+                                    },
+                                    "customDnsConfigs": {
+                                      "type": "array",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/customDnsConfigs"
+                                        },
+                                        "description": "Optional. Custom DNS configurations."
+                                      },
+                                      "nullable": true
+                                    },
+                                    "manualPrivateLinkServiceConnections": {
+                                      "type": "array",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/manualPrivateLinkServiceConnections"
+                                        },
+                                        "description": "Conditional. A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the remote resource. Required if `privateLinkServiceConnections` is empty."
+                                      },
+                                      "nullable": true
+                                    },
+                                    "privateLinkServiceConnections": {
+                                      "type": "array",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/privateLinkServiceConnections"
+                                        },
+                                        "description": "Conditional. A grouping of information about the connection to the remote resource. Required if `manualPrivateLinkServiceConnections` is empty."
+                                      },
+                                      "nullable": true
+                                    },
+                                    "enableTelemetry": {
+                                      "type": "bool",
+                                      "defaultValue": true,
+                                      "metadata": {
+                                        "description": "Optional. Enable/Disable usage telemetry for module."
+                                      }
+                                    }
+                                  },
+                                  "variables": {
+                                    "copy": [
+                                      {
+                                        "name": "formattedRoleAssignments",
+                                        "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                                        "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                                      }
+                                    ],
+                                    "builtInRoleNames": {
+                                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                                      "DNS Resolver Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f2ebee7-ffd4-4fc0-b3b7-664099fdad5d')]",
+                                      "DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314')]",
+                                      "Domain Services Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'eeaeda52-9324-47f6-8069-5d5bade478b2')]",
+                                      "Domain Services Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '361898ef-9ed1-48c2-849c-a832951106bb')]",
+                                      "Network Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
+                                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                                      "Private DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b12aa53e-6015-4669-85d0-8515ebb3ae7f')]",
+                                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                                      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
+                                    }
+                                  },
+                                  "resources": {
+                                    "avmTelemetry": {
+                                      "condition": "[parameters('enableTelemetry')]",
+                                      "type": "Microsoft.Resources/deployments",
+                                      "apiVersion": "2025-04-01",
+                                      "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.12.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                                      "properties": {
+                                        "mode": "Incremental",
+                                        "template": {
+                                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                          "contentVersion": "1.0.0.0",
+                                          "resources": [],
+                                          "outputs": {
+                                            "telemetry": {
+                                              "type": "String",
+                                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "privateEndpoint": {
+                                      "type": "Microsoft.Network/privateEndpoints",
+                                      "apiVersion": "2025-05-01",
+                                      "name": "[parameters('name')]",
+                                      "location": "[parameters('location')]",
+                                      "tags": "[parameters('tags')]",
+                                      "properties": {
+                                        "copy": [
+                                          {
+                                            "name": "applicationSecurityGroups",
+                                            "count": "[length(coalesce(parameters('applicationSecurityGroupResourceIds'), createArray()))]",
+                                            "input": {
+                                              "id": "[coalesce(parameters('applicationSecurityGroupResourceIds'), createArray())[copyIndex('applicationSecurityGroups')]]"
+                                            }
+                                          }
+                                        ],
+                                        "customDnsConfigs": "[coalesce(parameters('customDnsConfigs'), createArray())]",
+                                        "customNetworkInterfaceName": "[coalesce(parameters('customNetworkInterfaceName'), '')]",
+                                        "ipConfigurations": "[coalesce(parameters('ipConfigurations'), createArray())]",
+                                        "manualPrivateLinkServiceConnections": "[coalesce(parameters('manualPrivateLinkServiceConnections'), createArray())]",
+                                        "privateLinkServiceConnections": "[coalesce(parameters('privateLinkServiceConnections'), createArray())]",
+                                        "subnet": {
+                                          "id": "[parameters('subnetResourceId')]"
+                                        },
+                                        "ipVersionType": "[parameters('ipVersionType')]"
+                                      }
+                                    },
+                                    "privateEndpoint_lock": {
+                                      "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                                      "type": "Microsoft.Authorization/locks",
+                                      "apiVersion": "2020-05-01",
+                                      "scope": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]",
+                                      "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                                      "properties": {
+                                        "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                                        "notes": "[coalesce(tryGet(parameters('lock'), 'notes'), if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.'))]"
+                                      },
+                                      "dependsOn": [
+                                        "privateEndpoint"
+                                      ]
+                                    },
+                                    "privateEndpoint_roleAssignments": {
+                                      "copy": {
+                                        "name": "privateEndpoint_roleAssignments",
+                                        "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                                      },
+                                      "type": "Microsoft.Authorization/roleAssignments",
+                                      "apiVersion": "2022-04-01",
+                                      "scope": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]",
+                                      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Network/privateEndpoints', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                                      "properties": {
+                                        "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                                        "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                                        "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                                        "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                                        "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                                        "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                                        "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                                      },
+                                      "dependsOn": [
+                                        "privateEndpoint"
+                                      ]
+                                    },
+                                    "privateEndpoint_privateDnsZoneGroup": {
+                                      "condition": "[not(empty(parameters('privateDnsZoneGroup')))]",
+                                      "type": "Microsoft.Resources/deployments",
+                                      "apiVersion": "2025-04-01",
+                                      "name": "[format('{0}-PrivateEndpoint-PrivateDnsZoneGroup', uniqueString(deployment().name))]",
+                                      "properties": {
+                                        "expressionEvaluationOptions": {
+                                          "scope": "inner"
+                                        },
+                                        "mode": "Incremental",
+                                        "parameters": {
+                                          "name": {
+                                            "value": "[tryGet(parameters('privateDnsZoneGroup'), 'name')]"
+                                          },
+                                          "privateEndpointName": {
+                                            "value": "[parameters('name')]"
+                                          },
+                                          "privateDnsZoneConfigs": {
+                                            "value": "[parameters('privateDnsZoneGroup').privateDnsZoneGroupConfigs]"
+                                          }
+                                        },
+                                        "template": {
+                                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                          "languageVersion": "2.0",
+                                          "contentVersion": "1.0.0.0",
+                                          "metadata": {
+                                            "_generator": {
+                                              "name": "bicep",
+                                              "version": "0.41.2.15936",
+                                              "templateHash": "9935179114830442414"
+                                            },
+                                            "name": "Private Endpoint Private DNS Zone Groups",
+                                            "description": "This module deploys a Private Endpoint Private DNS Zone Group."
+                                          },
+                                          "definitions": {
+                                            "privateDnsZoneGroupConfigType": {
+                                              "type": "object",
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string",
+                                                  "nullable": true,
+                                                  "metadata": {
+                                                    "description": "Optional. The name of the private DNS zone group config."
+                                                  }
+                                                },
+                                                "privateDnsZoneResourceId": {
+                                                  "type": "string",
+                                                  "metadata": {
+                                                    "description": "Required. The resource id of the private DNS zone."
+                                                  }
+                                                }
+                                              },
+                                              "metadata": {
+                                                "__bicep_export!": true,
+                                                "description": "The type of a private DNS zone group configuration."
+                                              }
+                                            }
+                                          },
+                                          "parameters": {
+                                            "privateEndpointName": {
+                                              "type": "string",
+                                              "metadata": {
+                                                "description": "Conditional. The name of the parent private endpoint. Required if the template is used in a standalone deployment."
+                                              }
+                                            },
+                                            "privateDnsZoneConfigs": {
+                                              "type": "array",
+                                              "items": {
+                                                "$ref": "#/definitions/privateDnsZoneGroupConfigType"
+                                              },
+                                              "minLength": 1,
+                                              "maxLength": 5,
+                                              "metadata": {
+                                                "description": "Required. Array of private DNS zone configurations of the private DNS zone group. A DNS zone group can support up to 5 DNS zones."
+                                              }
+                                            },
+                                            "name": {
+                                              "type": "string",
+                                              "defaultValue": "default",
+                                              "metadata": {
+                                                "description": "Optional. The name of the private DNS zone group."
+                                              }
+                                            }
+                                          },
+                                          "resources": {
+                                            "privateEndpoint": {
+                                              "existing": true,
+                                              "type": "Microsoft.Network/privateEndpoints",
+                                              "apiVersion": "2025-05-01",
+                                              "name": "[parameters('privateEndpointName')]"
+                                            },
+                                            "privateDnsZoneGroup": {
+                                              "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                                              "apiVersion": "2025-05-01",
+                                              "name": "[format('{0}/{1}', parameters('privateEndpointName'), parameters('name'))]",
+                                              "properties": {
+                                                "copy": [
+                                                  {
+                                                    "name": "privateDnsZoneConfigs",
+                                                    "count": "[length(parameters('privateDnsZoneConfigs'))]",
+                                                    "input": {
+                                                      "name": "[coalesce(tryGet(parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigs')], 'name'), last(split(parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigs')].privateDnsZoneResourceId, '/')))]",
+                                                      "properties": {
+                                                        "privateDnsZoneId": "[parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigs')].privateDnsZoneResourceId]"
+                                                      }
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "outputs": {
+                                            "name": {
+                                              "type": "string",
+                                              "metadata": {
+                                                "description": "The name of the private endpoint DNS zone group."
+                                              },
+                                              "value": "[parameters('name')]"
+                                            },
+                                            "resourceId": {
+                                              "type": "string",
+                                              "metadata": {
+                                                "description": "The resource ID of the private endpoint DNS zone group."
+                                              },
+                                              "value": "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', parameters('privateEndpointName'), parameters('name'))]"
+                                            },
+                                            "resourceGroupName": {
+                                              "type": "string",
+                                              "metadata": {
+                                                "description": "The resource group the private endpoint DNS zone group was deployed into."
+                                              },
+                                              "value": "[resourceGroup().name]"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "dependsOn": [
+                                        "privateEndpoint"
+                                      ]
+                                    }
+                                  },
+                                  "outputs": {
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource group the private endpoint was deployed into."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the private endpoint."
+                                      },
+                                      "value": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]"
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the private endpoint."
+                                      },
+                                      "value": "[parameters('name')]"
+                                    },
+                                    "location": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The location the resource was deployed into."
+                                      },
+                                      "value": "[reference('privateEndpoint', '2025-05-01', 'full').location]"
+                                    },
+                                    "customDnsConfigs": {
+                                      "type": "array",
+                                      "metadata": {
+                                        "__bicep_resource_derived_type!": {
+                                          "source": "Microsoft.Network/privateEndpoints@2025-05-01#properties/properties/properties/customDnsConfigs",
+                                          "output": true
+                                        },
+                                        "description": "The custom DNS configurations of the private endpoint."
+                                      },
+                                      "value": "[reference('privateEndpoint').customDnsConfigs]"
+                                    },
+                                    "networkInterfaceResourceIds": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "metadata": {
+                                        "description": "The resource IDs of the network interfaces associated with the private endpoint."
+                                      },
+                                      "value": "[map(reference('privateEndpoint').networkInterfaces, lambda('nic', lambdaVariables('nic').id))]"
+                                    },
+                                    "groupId": {
+                                      "type": "string",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "The group Id for the private endpoint Group."
+                                      },
+                                      "value": "[coalesce(tryGet(tryGet(tryGet(tryGet(reference('privateEndpoint'), 'manualPrivateLinkServiceConnections'), 0, 'properties'), 'groupIds'), 0), tryGet(tryGet(tryGet(tryGet(reference('privateEndpoint'), 'privateLinkServiceConnections'), 0, 'properties'), 'groupIds'), 0))]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "registry",
+                                "registry_replications"
+                              ]
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The Name of the Azure container registry."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "loginServer": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The reference to the Azure container registry."
+                              },
+                              "value": "[reference('registry').loginServer]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the Azure container registry."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the Azure container registry."
+                              },
+                              "value": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]"
+                            },
+                            "systemAssignedMIPrincipalId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "The principal ID of the system assigned identity."
+                              },
+                              "value": "[tryGet(tryGet(reference('registry', '2025-06-01-preview', 'full'), 'identity'), 'principalId')]"
+                            },
+                            "location": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The location the resource was deployed into."
+                              },
+                              "value": "[reference('registry', '2025-06-01-preview', 'full').location]"
+                            },
+                            "credentialSetsSystemAssignedMIPrincipalIds": {
+                              "type": "array",
+                              "metadata": {
+                                "description": "The Principal IDs of the ACR Credential Sets system-assigned identities."
+                              },
+                              "copy": {
+                                "count": "[length(range(0, length(coalesce(parameters('credentialSets'), createArray()))))]",
+                                "input": "[tryGet(tryGet(reference(format('registry_credentialSets[{0}]', range(0, length(coalesce(parameters('credentialSets'), createArray())))[copyIndex()])).outputs, 'systemAssignedMIPrincipalId'), 'value')]"
+                              }
+                            },
+                            "credentialSetsResourceIds": {
+                              "type": "array",
+                              "metadata": {
+                                "description": "The Resource IDs of the ACR Credential Sets."
+                              },
+                              "copy": {
+                                "count": "[length(range(0, length(coalesce(parameters('credentialSets'), createArray()))))]",
+                                "input": "[reference(format('registry_credentialSets[{0}]', range(0, length(coalesce(parameters('credentialSets'), createArray())))[copyIndex()])).outputs.resourceId.value]"
+                              }
+                            },
+                            "privateEndpoints": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/privateEndpointOutputType"
+                              },
+                              "metadata": {
+                                "description": "The private endpoints of the Azure container registry."
+                              },
+                              "copy": {
+                                "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]",
+                                "input": {
+                                  "name": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.name.value]",
+                                  "resourceId": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.resourceId.value]",
+                                  "groupId": "[tryGet(tryGet(reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs, 'groupId'), 'value')]",
+                                  "customDnsConfigs": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.customDnsConfigs.value]",
+                                  "networkInterfaceResourceIds": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.networkInterfaceResourceIds.value]"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the container registry."
+                      },
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', take(format('avm.res.containerregistry.{0}', parameters('name')), 64)), '2025-04-01').outputs.name.value]"
+                    },
+                    "loginServer": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The login server URL."
+                      },
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', take(format('avm.res.containerregistry.{0}', parameters('name')), 64)), '2025-04-01').outputs.loginServer.value]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the container registry."
+                      },
+                      "value": "[reference(resourceId('Microsoft.Resources/deployments', take(format('avm.res.containerregistry.{0}', parameters('name')), 64)), '2025-04-01').outputs.resourceId.value]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "[format('privateDnsZoneDeployments[{0}]', variables('dnsZoneIndex').containerRegistry)]",
+                "virtualNetwork"
+              ]
+            },
             "hostingplan": {
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2025-04-01",
@@ -47132,7 +51238,10 @@
                     "value": "[reference('hostingplan').outputs.resourceId.value]"
                   },
                   "linuxFxVersion": {
-                    "value": "[format('DOCKER|{0}.azurecr.io/da-api:{1}', parameters('containerRegistryName'), parameters('imageTag'))]"
+                    "value": "[variables('placeholderContainerImage')]"
+                  },
+                  "acrUseManagedIdentityCreds": {
+                    "value": true
                   },
                   "virtualNetworkSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.webserverfarmSubnetResourceId.value), createObject('value', ''))]",
                   "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
@@ -47186,7 +51295,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.44.1.10279",
-                      "templateHash": "7219841793741923362"
+                      "templateHash": "15548497476269761773"
                     }
                   },
                   "definitions": {
@@ -47698,6 +51807,13 @@
                         "description": "Optional. Whether to route content share traffic through the virtual network."
                       }
                     },
+                    "acrUseManagedIdentityCreds": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Use the app managed identity to authenticate ACR image pulls."
+                      }
+                    },
                     "privateEndpoints": {
                       "type": "array",
                       "items": {
@@ -47793,7 +51909,8 @@
                               "healthCheckPath": "[if(not(empty(parameters('healthCheckPath'))), parameters('healthCheckPath'), null())]",
                               "webSocketsEnabled": "[parameters('webSocketsEnabled')]",
                               "appCommandLine": "[parameters('appCommandLine')]",
-                              "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]"
+                              "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]",
+                              "acrUseManagedIdentityCreds": "[parameters('acrUseManagedIdentityCreds')]"
                             }
                           },
                           "e2eEncryptionEnabled": {
@@ -62705,7 +66822,10 @@
                     "value": "[reference('hostingplan').outputs.resourceId.value]"
                   },
                   "linuxFxVersion": {
-                    "value": "[format('DOCKER|{0}.azurecr.io/da-api-dotnet:{1}', parameters('containerRegistryName'), parameters('imageTag'))]"
+                    "value": "[variables('placeholderContainerImage')]"
+                  },
+                  "acrUseManagedIdentityCreds": {
+                    "value": true
                   },
                   "virtualNetworkSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.webserverfarmSubnetResourceId.value), createObject('value', ''))]",
                   "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
@@ -62755,7 +66875,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.44.1.10279",
-                      "templateHash": "7219841793741923362"
+                      "templateHash": "15548497476269761773"
                     }
                   },
                   "definitions": {
@@ -63267,6 +67387,13 @@
                         "description": "Optional. Whether to route content share traffic through the virtual network."
                       }
                     },
+                    "acrUseManagedIdentityCreds": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Use the app managed identity to authenticate ACR image pulls."
+                      }
+                    },
                     "privateEndpoints": {
                       "type": "array",
                       "items": {
@@ -63362,7 +67489,8 @@
                               "healthCheckPath": "[if(not(empty(parameters('healthCheckPath'))), parameters('healthCheckPath'), null())]",
                               "webSocketsEnabled": "[parameters('webSocketsEnabled')]",
                               "appCommandLine": "[parameters('appCommandLine')]",
-                              "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]"
+                              "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]",
+                              "acrUseManagedIdentityCreds": "[parameters('acrUseManagedIdentityCreds')]"
                             }
                           },
                           "e2eEncryptionEnabled": {
@@ -78273,7 +82401,10 @@
                     "value": "[reference('hostingplan').outputs.resourceId.value]"
                   },
                   "linuxFxVersion": {
-                    "value": "[format('DOCKER|{0}.azurecr.io/da-app:{1}', parameters('containerRegistryName'), parameters('imageTag'))]"
+                    "value": "[variables('placeholderContainerImage')]"
+                  },
+                  "acrUseManagedIdentityCreds": {
+                    "value": true
                   },
                   "virtualNetworkSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.webserverfarmSubnetResourceId.value), createObject('value', ''))]",
                   "publicNetworkAccess": {
@@ -78299,7 +82430,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.44.1.10279",
-                      "templateHash": "7219841793741923362"
+                      "templateHash": "15548497476269761773"
                     }
                   },
                   "definitions": {
@@ -78811,6 +82942,13 @@
                         "description": "Optional. Whether to route content share traffic through the virtual network."
                       }
                     },
+                    "acrUseManagedIdentityCreds": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Use the app managed identity to authenticate ACR image pulls."
+                      }
+                    },
                     "privateEndpoints": {
                       "type": "array",
                       "items": {
@@ -78906,7 +83044,8 @@
                               "healthCheckPath": "[if(not(empty(parameters('healthCheckPath'))), parameters('healthCheckPath'), null())]",
                               "webSocketsEnabled": "[parameters('webSocketsEnabled')]",
                               "appCommandLine": "[parameters('appCommandLine')]",
-                              "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]"
+                              "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]",
+                              "acrUseManagedIdentityCreds": "[parameters('acrUseManagedIdentityCreds')]"
                             }
                           },
                           "e2eEncryptionEnabled": {
@@ -93813,6 +97952,12 @@
                     "value": "[reference('cosmosDBModule').outputs.name.value]"
                   },
                   "backendAppServicePrincipalId": "[if(equals(parameters('backendRuntimeStack'), 'python'), createObject('value', reference('backend_docker').outputs.identityPrincipalId.value), createObject('value', reference('backend_csapi_docker').outputs.identityPrincipalId.value))]",
+                  "frontendAppServicePrincipalId": {
+                    "value": "[reference('frontend_docker').outputs.identityPrincipalId.value]"
+                  },
+                  "containerRegistryResourceId": {
+                    "value": "[reference('containerRegistry').outputs.resourceId.value]"
+                  },
                   "aiFoundryResourceId": "[if(variables('useExistingAIProject'), createObject('value', reference('existing_project_setup').outputs.resourceId.value), createObject('value', reference('ai_foundry_project').outputs.resourceId.value))]",
                   "useExistingAIProject": {
                     "value": "[variables('useExistingAIProject')]"
@@ -93828,7 +97973,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.44.1.10279",
-                      "templateHash": "15652761467149754710"
+                      "templateHash": "1138212285559024015"
                     }
                   },
                   "parameters": {
@@ -93874,6 +98019,13 @@
                         "description": "Principal ID of the backend App Service system-assigned identity (empty if not deployed)."
                       }
                     },
+                    "frontendAppServicePrincipalId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Principal ID of the frontend App Service system-assigned identity (empty if not deployed)."
+                      }
+                    },
                     "aiFoundryResourceId": {
                       "type": "string",
                       "defaultValue": "",
@@ -93901,6 +98053,13 @@
                       "metadata": {
                         "description": "Name of the Cosmos DB account (empty if not deployed)."
                       }
+                    },
+                    "containerRegistryResourceId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Resource ID of the Azure Container Registry (empty if not deployed)."
+                      }
                     }
                   },
                   "variables": {
@@ -93914,7 +98073,8 @@
                       "searchIndexDataReader": "1407120a-92aa-4202-b7e9-c0e197c71c8f",
                       "searchServiceContributor": "7ca78c08-252a-4471-8644-bb5ff32d4ba0",
                       "storageBlobDataContributor": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
-                      "storageBlobDataReader": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1"
+                      "storageBlobDataReader": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
+                      "acrPull": "7f951dda-4ed3-4680-a7ca-43fe172d538d"
                     }
                   },
                   "resources": [
@@ -94023,6 +98183,30 @@
                         "principalId": "[parameters('backendAppServicePrincipalId')]",
                         "roleDefinitionId": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', parameters('cosmosDbAccountName'), '00000000-0000-0000-0000-000000000002')]",
                         "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosDbAccountName'))]"
+                      }
+                    },
+                    {
+                      "condition": "[and(not(empty(parameters('containerRegistryResourceId'))), not(empty(parameters('backendAppServicePrincipalId'))))]",
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/')))]",
+                      "name": "[guid(parameters('solutionName'), resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/'))), parameters('backendAppServicePrincipalId'), variables('roleDefinitions').acrPull)]",
+                      "properties": {
+                        "principalId": "[parameters('backendAppServicePrincipalId')]",
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefinitions').acrPull)]",
+                        "principalType": "ServicePrincipal"
+                      }
+                    },
+                    {
+                      "condition": "[and(not(empty(parameters('containerRegistryResourceId'))), not(empty(parameters('frontendAppServicePrincipalId'))))]",
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/')))]",
+                      "name": "[guid(parameters('solutionName'), resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/'))), parameters('frontendAppServicePrincipalId'), variables('roleDefinitions').acrPull)]",
+                      "properties": {
+                        "principalId": "[parameters('frontendAppServicePrincipalId')]",
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefinitions').acrPull)]",
+                        "principalType": "ServicePrincipal"
                       }
                     },
                     {
@@ -94211,8 +98395,10 @@
                 "ai_search",
                 "backend_csapi_docker",
                 "backend_docker",
+                "containerRegistry",
                 "cosmosDBModule",
                 "existing_project_setup",
+                "frontend_docker",
                 "storage_account"
               ]
             }
@@ -94238,6 +98424,27 @@
                 "description": "WAF deployment type."
               },
               "value": "[if(parameters('enablePrivateNetworking'), 'WAF', 'Non-WAF')]"
+            },
+            "AZURE_ENV_CONTAINER_REGISTRY_NAME": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the dedicated Azure Container Registry."
+              },
+              "value": "[reference('containerRegistry').outputs.name.value]"
+            },
+            "AZURE_CONTAINER_REGISTRY_ENDPOINT": {
+              "type": "string",
+              "metadata": {
+                "description": "Login server of the dedicated Azure Container Registry."
+              },
+              "value": "[reference('containerRegistry').outputs.loginServer.value]"
+            },
+            "AZURE_ENV_IMAGE_TAG": {
+              "type": "string",
+              "metadata": {
+                "description": "Docker image tag used for app deployments."
+              },
+              "value": "[parameters('imageTag')]"
             },
             "AZURE_COSMOSDB_ACCOUNT": {
               "type": "string",
@@ -94570,7 +98777,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "4272848169429759010"
+              "templateHash": "15841029785825128032"
             }
           },
           "parameters": {
@@ -94703,9 +98910,9 @@
             },
             "containerRegistryName": {
               "type": "string",
-              "defaultValue": "dataagentscontainerreg",
+              "defaultValue": "",
               "metadata": {
-                "description": "Optional. Name of the Azure Container Registry."
+                "description": "Optional. Name of the Azure Container Registry. Empty derives a per-deployment name (cr<suffix>)."
               }
             },
             "backendRuntimeStack": {
@@ -94840,6 +99047,7 @@
             "solutionSuffix": "[toLower(trim(replace(replace(replace(replace(replace(replace(format('{0}{1}', parameters('solutionName'), parameters('solutionUniqueText')), '-', ''), '_', ''), '.', ''), '/', ''), ' ', ''), '*', '')))]",
             "deployerInfo": "[deployer()]",
             "deployingUserPrincipalId": "[variables('deployerInfo').objectId]",
+            "containerRegistryResourceName": "[if(not(empty(parameters('containerRegistryName'))), parameters('containerRegistryName'), take(format('cr{0}', variables('solutionSuffix')), 50))]",
             "createdBy": "[if(contains(variables('deployerInfo'), 'userPrincipalName'), split(variables('deployerInfo').userPrincipalName, '@')[0], variables('deployerInfo').objectId)]",
             "existingTags": "[coalesce(resourceGroup().tags, createObject())]",
             "useExistingAIProject": "[not(empty(parameters('existingFoundryProjectResourceId')))]",
@@ -94876,10 +99084,11 @@
             ],
             "aiFoundrySubscriptionId": "[if(variables('useExistingAIProject'), split(parameters('existingFoundryProjectResourceId'), '/')[2], subscription().subscriptionId)]",
             "aiFoundryResourceGroupName": "[if(variables('useExistingAIProject'), split(parameters('existingFoundryProjectResourceId'), '/')[4], resourceGroup().name)]",
-            "backendApiImageName": "[format('DOCKER|{0}.azurecr.io/da-api:{1}', parameters('containerRegistryName'), parameters('imageTag'))]",
-            "backendCsApiImageName": "[format('DOCKER|{0}.azurecr.io/da-api-dotnet:{1}', parameters('containerRegistryName'), parameters('imageTag'))]",
-            "frontendImageName": "[format('DOCKER|{0}.azurecr.io/da-app:{1}', parameters('containerRegistryName'), parameters('imageTag'))]",
-            "reactAppLayoutConfig": "{\n  \"appConfig\": {\n      \"CHAT_CHATHISTORY\": {\n        \"CHAT\": 70,\n        \"CHATHISTORY\": 30\n      }\n    }\n  }\n}"
+            "placeholderContainerImage": "DOCKER|mcr.microsoft.com/azuredocs/aci-helloworld:latest",
+            "backendApiImageName": "[variables('placeholderContainerImage')]",
+            "backendCsApiImageName": "[variables('placeholderContainerImage')]",
+            "frontendImageName": "[variables('placeholderContainerImage')]",
+            "reactAppLayoutConfig": "{\r\n  \"appConfig\": {\r\n      \"CHAT_CHATHISTORY\": {\r\n        \"CHAT\": 70,\r\n        \"CHATHISTORY\": 30\r\n      }\r\n    }\r\n  }\r\n}"
           },
           "resources": [
             {
@@ -97292,6 +101501,186 @@
               }
             },
             {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[take(format('module.container-registry.{0}', parameters('solutionName')), 64)]",
+              "resourceGroup": "[resourceGroup().name]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "solutionName": {
+                    "value": "[variables('solutionSuffix')]"
+                  },
+                  "name": {
+                    "value": "[variables('containerRegistryResourceName')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "tags": {
+                    "value": "[variables('existingTags')]"
+                  },
+                  "sku": {
+                    "value": "Standard"
+                  },
+                  "publicNetworkAccess": {
+                    "value": "Enabled"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.44.1.10279",
+                      "templateHash": "6730962297935458636"
+                    }
+                  },
+                  "parameters": {
+                    "solutionName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Solution name used for naming convention."
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "defaultValue": "[replace(format('cr{0}', parameters('solutionName')), '-', '')]",
+                      "metadata": {
+                        "description": "Name of the container registry."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Azure region for deployment."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "defaultValue": {},
+                      "metadata": {
+                        "description": "Resource tags."
+                      }
+                    },
+                    "sku": {
+                      "type": "string",
+                      "defaultValue": "Standard",
+                      "allowedValues": [
+                        "Basic",
+                        "Standard",
+                        "Premium"
+                      ],
+                      "metadata": {
+                        "description": "SKU for the container registry."
+                      }
+                    },
+                    "adminUserEnabled": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Enable admin user."
+                      }
+                    },
+                    "publicNetworkAccess": {
+                      "type": "string",
+                      "defaultValue": "Enabled",
+                      "allowedValues": [
+                        "Enabled",
+                        "Disabled"
+                      ],
+                      "metadata": {
+                        "description": "Public network access setting."
+                      }
+                    },
+                    "exportPolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "enabled",
+                      "metadata": {
+                        "description": "Export policy status."
+                      }
+                    },
+                    "retentionPolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "disabled",
+                      "metadata": {
+                        "description": "Retention policy status."
+                      }
+                    },
+                    "identity": {
+                      "type": "object",
+                      "defaultValue": {
+                        "type": "SystemAssigned"
+                      },
+                      "metadata": {
+                        "description": "Optional. Managed identity configuration for the resource."
+                      }
+                    }
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.ContainerRegistry/registries",
+                      "apiVersion": "2025-04-01",
+                      "name": "[parameters('name')]",
+                      "location": "[parameters('location')]",
+                      "tags": "[parameters('tags')]",
+                      "sku": {
+                        "name": "[parameters('sku')]"
+                      },
+                      "identity": "[parameters('identity')]",
+                      "properties": {
+                        "adminUserEnabled": "[parameters('adminUserEnabled')]",
+                        "publicNetworkAccess": "[parameters('publicNetworkAccess')]",
+                        "dataEndpointEnabled": false,
+                        "networkRuleBypassOptions": "AzureServices",
+                        "policies": {
+                          "exportPolicy": {
+                            "status": "[parameters('exportPolicyStatus')]"
+                          },
+                          "retentionPolicy": {
+                            "status": "[parameters('retentionPolicyStatus')]",
+                            "days": 7
+                          },
+                          "trustPolicy": {
+                            "status": "disabled",
+                            "type": "Notary"
+                          }
+                        },
+                        "zoneRedundancy": "Disabled"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the container registry."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "loginServer": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The login server URL."
+                      },
+                      "value": "[reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '2025-04-01').loginServer]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the container registry."
+                      },
+                      "value": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]"
+                    }
+                  }
+                }
+              }
+            },
+            {
               "condition": "[equals(parameters('backendRuntimeStack'), 'python')]",
               "type": "Microsoft.Resources/deployments",
               "apiVersion": "2025-04-01",
@@ -97317,6 +101706,9 @@
                   },
                   "linuxFxVersion": {
                     "value": "[variables('backendApiImageName')]"
+                  },
+                  "acrUseManagedIdentityCreds": {
+                    "value": true
                   },
                   "appSettings": {
                     "value": {
@@ -97365,7 +101757,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.44.1.10279",
-                      "templateHash": "9185565370457912659"
+                      "templateHash": "13673771886806254197"
                     }
                   },
                   "parameters": {
@@ -97478,6 +101870,13 @@
                       "metadata": {
                         "description": "Optional. Managed identity configuration for the resource."
                       }
+                    },
+                    "acrUseManagedIdentityCreds": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Use the app managed identity to authenticate ACR image pulls."
+                      }
                     }
                   },
                   "resources": [
@@ -97521,7 +101920,8 @@
                           "minTlsVersion": "1.2",
                           "healthCheckPath": "[if(not(empty(parameters('healthCheckPath'))), parameters('healthCheckPath'), null())]",
                           "webSocketsEnabled": "[parameters('webSocketsEnabled')]",
-                          "appCommandLine": "[parameters('appCommandLine')]"
+                          "appCommandLine": "[parameters('appCommandLine')]",
+                          "acrUseManagedIdentityCreds": "[parameters('acrUseManagedIdentityCreds')]"
                         },
                         "endToEndEncryptionEnabled": true
                       }
@@ -97641,6 +102041,9 @@
                   "linuxFxVersion": {
                     "value": "[variables('backendCsApiImageName')]"
                   },
+                  "acrUseManagedIdentityCreds": {
+                    "value": true
+                  },
                   "appSettings": {
                     "value": {
                       "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-insights.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.instrumentationKey.value]",
@@ -97684,7 +102087,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.44.1.10279",
-                      "templateHash": "9185565370457912659"
+                      "templateHash": "13673771886806254197"
                     }
                   },
                   "parameters": {
@@ -97797,6 +102200,13 @@
                       "metadata": {
                         "description": "Optional. Managed identity configuration for the resource."
                       }
+                    },
+                    "acrUseManagedIdentityCreds": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Use the app managed identity to authenticate ACR image pulls."
+                      }
                     }
                   },
                   "resources": [
@@ -97840,7 +102250,8 @@
                           "minTlsVersion": "1.2",
                           "healthCheckPath": "[if(not(empty(parameters('healthCheckPath'))), parameters('healthCheckPath'), null())]",
                           "webSocketsEnabled": "[parameters('webSocketsEnabled')]",
-                          "appCommandLine": "[parameters('appCommandLine')]"
+                          "appCommandLine": "[parameters('appCommandLine')]",
+                          "acrUseManagedIdentityCreds": "[parameters('acrUseManagedIdentityCreds')]"
                         },
                         "endToEndEncryptionEnabled": true
                       }
@@ -97959,6 +102370,9 @@
                   "linuxFxVersion": {
                     "value": "[variables('frontendImageName')]"
                   },
+                  "acrUseManagedIdentityCreds": {
+                    "value": true
+                  },
                   "appSettings": {
                     "value": {
                       "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-insights.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.instrumentationKey.value]",
@@ -97976,7 +102390,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.44.1.10279",
-                      "templateHash": "9185565370457912659"
+                      "templateHash": "13673771886806254197"
                     }
                   },
                   "parameters": {
@@ -98089,6 +102503,13 @@
                       "metadata": {
                         "description": "Optional. Managed identity configuration for the resource."
                       }
+                    },
+                    "acrUseManagedIdentityCreds": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Use the app managed identity to authenticate ACR image pulls."
+                      }
                     }
                   },
                   "resources": [
@@ -98132,7 +102553,8 @@
                           "minTlsVersion": "1.2",
                           "healthCheckPath": "[if(not(empty(parameters('healthCheckPath'))), parameters('healthCheckPath'), null())]",
                           "webSocketsEnabled": "[parameters('webSocketsEnabled')]",
-                          "appCommandLine": "[parameters('appCommandLine')]"
+                          "appCommandLine": "[parameters('appCommandLine')]",
+                          "acrUseManagedIdentityCreds": "[parameters('acrUseManagedIdentityCreds')]"
                         },
                         "endToEndEncryptionEnabled": true
                       }
@@ -98260,6 +102682,12 @@
                     "value": "[parameters('deployingUserPrincipalType')]"
                   },
                   "backendAppServicePrincipalId": "[if(equals(parameters('backendRuntimeStack'), 'python'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-service-pybackend.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.identityPrincipalId.value), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-service-csbackend.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.identityPrincipalId.value))]",
+                  "frontendAppServicePrincipalId": {
+                    "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-service-frontend.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.identityPrincipalId.value]"
+                  },
+                  "containerRegistryResourceId": {
+                    "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.container-registry.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.resourceId.value]"
+                  },
                   "cosmosDbAccountName": {
                     "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.cosmos-db-nosql.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.name.value]"
                   }
@@ -98271,7 +102699,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.44.1.10279",
-                      "templateHash": "18394750597129424907"
+                      "templateHash": "816923035574542416"
                     }
                   },
                   "parameters": {
@@ -98315,6 +102743,13 @@
                       "defaultValue": "",
                       "metadata": {
                         "description": "Principal ID of the backend App Service system-assigned identity (empty if not deployed)."
+                      }
+                    },
+                    "frontendAppServicePrincipalId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Principal ID of the frontend App Service system-assigned identity (empty if not deployed)."
                       }
                     },
                     "deployerPrincipalId": {
@@ -98362,6 +102797,13 @@
                       "metadata": {
                         "description": "Name of the Cosmos DB account (empty if not deployed)."
                       }
+                    },
+                    "containerRegistryResourceId": {
+                      "type": "string",
+                      "defaultValue": "",
+                      "metadata": {
+                        "description": "Resource ID of the Azure Container Registry (empty if not deployed)."
+                      }
                     }
                   },
                   "variables": {
@@ -98376,7 +102818,8 @@
                       "searchIndexDataContributor": "8ebe5a00-799e-43f5-93ac-243d3dce84a7",
                       "searchServiceContributor": "7ca78c08-252a-4471-8644-bb5ff32d4ba0",
                       "storageBlobDataContributor": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
-                      "storageBlobDataReader": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1"
+                      "storageBlobDataReader": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
+                      "acrPull": "7f951dda-4ed3-4680-a7ca-43fe172d538d"
                     }
                   },
                   "resources": [
@@ -98545,6 +102988,30 @@
                         "principalId": "[parameters('deployerPrincipalId')]",
                         "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefinitions').storageBlobDataContributor)]",
                         "principalType": "[parameters('deployerPrincipalType')]"
+                      }
+                    },
+                    {
+                      "condition": "[and(not(empty(parameters('containerRegistryResourceId'))), not(empty(parameters('backendAppServicePrincipalId'))))]",
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/')))]",
+                      "name": "[guid(parameters('solutionName'), resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/'))), parameters('backendAppServicePrincipalId'), variables('roleDefinitions').acrPull)]",
+                      "properties": {
+                        "principalId": "[parameters('backendAppServicePrincipalId')]",
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefinitions').acrPull)]",
+                        "principalType": "ServicePrincipal"
+                      }
+                    },
+                    {
+                      "condition": "[and(not(empty(parameters('containerRegistryResourceId'))), not(empty(parameters('frontendAppServicePrincipalId'))))]",
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/')))]",
+                      "name": "[guid(parameters('solutionName'), resourceId('Microsoft.ContainerRegistry/registries', last(split(parameters('containerRegistryResourceId'), '/'))), parameters('frontendAppServicePrincipalId'), variables('roleDefinitions').acrPull)]",
+                      "properties": {
+                        "principalId": "[parameters('frontendAppServicePrincipalId')]",
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefinitions').acrPull)]",
+                        "principalType": "ServicePrincipal"
                       }
                     },
                     {
@@ -98733,8 +103200,10 @@
                 "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.ai-search.{0}', parameters('solutionName')), 64))]",
                 "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-service-csbackend.{0}', parameters('solutionName')), 64))]",
                 "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-service-pybackend.{0}', parameters('solutionName')), 64))]",
+                "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.container-registry.{0}', parameters('solutionName')), 64))]",
                 "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.cosmos-db-nosql.{0}', parameters('solutionName')), 64))]",
                 "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('aiFoundrySubscriptionId'), variables('aiFoundryResourceGroupName')), 'Microsoft.Resources/deployments', take(format('module.existing-project-setup.{0}', parameters('solutionName')), 64))]",
+                "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.app-service-frontend.{0}', parameters('solutionName')), 64))]",
                 "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.storage-account.{0}', parameters('solutionName')), 64))]"
               ]
             }
@@ -98746,6 +103215,27 @@
                 "description": "Solution suffix used for naming resources"
               },
               "value": "[variables('solutionSuffix')]"
+            },
+            "AZURE_ENV_CONTAINER_REGISTRY_NAME": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the dedicated Azure Container Registry."
+              },
+              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.container-registry.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.name.value]"
+            },
+            "AZURE_CONTAINER_REGISTRY_ENDPOINT": {
+              "type": "string",
+              "metadata": {
+                "description": "Login server of the dedicated Azure Container Registry."
+              },
+              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, resourceGroup().name), 'Microsoft.Resources/deployments', take(format('module.container-registry.{0}', parameters('solutionName')), 64)), '2025-04-01').outputs.loginServer.value]"
+            },
+            "AZURE_ENV_IMAGE_TAG": {
+              "type": "string",
+              "metadata": {
+                "description": "Docker image tag used for app deployments."
+              },
+              "value": "[parameters('imageTag')]"
             },
             "RESOURCE_GROUP_NAME": {
               "type": "string",
@@ -99011,6 +103501,27 @@
         "description": "WAF deployment type (AVM only)."
       },
       "value": "[if(variables('isAvm'), reference('avmDeployment').outputs.DEPLOYMENT_TYPE.value, 'N/A')]"
+    },
+    "AZURE_ENV_CONTAINER_REGISTRY_NAME": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the dedicated Azure Container Registry."
+      },
+      "value": "[if(variables('isAvm'), reference('avmDeployment').outputs.AZURE_ENV_CONTAINER_REGISTRY_NAME.value, reference('bicepDeployment').outputs.AZURE_ENV_CONTAINER_REGISTRY_NAME.value)]"
+    },
+    "AZURE_CONTAINER_REGISTRY_ENDPOINT": {
+      "type": "string",
+      "metadata": {
+        "description": "Login server of the dedicated Azure Container Registry."
+      },
+      "value": "[if(variables('isAvm'), reference('avmDeployment').outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT.value, reference('bicepDeployment').outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT.value)]"
+    },
+    "AZURE_ENV_IMAGE_TAG": {
+      "type": "string",
+      "metadata": {
+        "description": "Docker image tag used for app deployments."
+      },
+      "value": "[if(variables('isAvm'), reference('avmDeployment').outputs.AZURE_ENV_IMAGE_TAG.value, reference('bicepDeployment').outputs.AZURE_ENV_IMAGE_TAG.value)]"
     },
     "AZURE_COSMOSDB_ACCOUNT": {
       "type": "string",

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "12984022811060325727"
+      "templateHash": "3587964259397477422"
     }
   },
   "parameters": {
@@ -62,7 +62,7 @@
         "azd": {
           "type": "location",
           "usageName": [
-            "OpenAI.GlobalStandard.gpt4.1-mini,100",
+            "OpenAI.GlobalStandard.gpt-5.4-mini,100",
             "OpenAI.GlobalStandard.text-embedding-3-small,80"
           ]
         },
@@ -82,14 +82,14 @@
     },
     "gptModelName": {
       "type": "string",
-      "defaultValue": "gpt-4.1-mini",
+      "defaultValue": "gpt-5.4-mini",
       "metadata": {
         "description": "Optional. Name of the GPT model to deploy."
       }
     },
     "gptModelVersion": {
       "type": "string",
-      "defaultValue": "2025-04-14",
+      "defaultValue": "2026-03-17",
       "metadata": {
         "description": "Optional. Version of the GPT model to deploy."
       }
@@ -473,7 +473,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "2782862649368459379"
+              "templateHash": "15406414339800399151"
             }
           },
           "parameters": {
@@ -581,7 +581,7 @@
                 "azd": {
                   "type": "location",
                   "usageName": [
-                    "OpenAI.GlobalStandard.gpt4.1-mini,100",
+                    "OpenAI.GlobalStandard.gpt-5.4-mini,100",
                     "OpenAI.GlobalStandard.text-embedding-3-small,80"
                   ]
                 },
@@ -601,14 +601,14 @@
             },
             "gptModelName": {
               "type": "string",
-              "defaultValue": "gpt-4.1-mini",
+              "defaultValue": "gpt-5.4-mini",
               "metadata": {
                 "description": "Optional. Name of the GPT model to deploy."
               }
             },
             "gptModelVersion": {
               "type": "string",
-              "defaultValue": "2025-04-14",
+              "defaultValue": "2026-03-17",
               "metadata": {
                 "description": "Optional. Version of the GPT model to deploy."
               }
@@ -98777,7 +98777,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "15841029785825128032"
+              "templateHash": "15646615221951775073"
             }
           },
           "parameters": {
@@ -98829,7 +98829,7 @@
                 "azd": {
                   "type": "location",
                   "usageName": [
-                    "OpenAI.GlobalStandard.gpt4.1-mini,100",
+                    "OpenAI.GlobalStandard.gpt-5.4-mini,100",
                     "OpenAI.GlobalStandard.text-embedding-3-small,80"
                   ]
                 },
@@ -98849,14 +98849,14 @@
             },
             "gptModelName": {
               "type": "string",
-              "defaultValue": "gpt-4.1-mini",
+              "defaultValue": "gpt-5.4-mini",
               "metadata": {
                 "description": "Optional. Name of the GPT model to deploy."
               }
             },
             "gptModelVersion": {
               "type": "string",
-              "defaultValue": "2025-04-14",
+              "defaultValue": "2026-03-17",
               "metadata": {
                 "description": "Optional. Version of the GPT model to deploy."
               }

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -40,7 +40,7 @@ param tags object = {}
   azd: {
     type: 'location'
     usageName: [
-      'OpenAI.GlobalStandard.gpt4.1-mini,100'
+      'OpenAI.GlobalStandard.gpt-5.4-mini,100'
       'OpenAI.GlobalStandard.text-embedding-3-small,80'
     ]
   }
@@ -60,10 +60,10 @@ param azureAiServiceLocation string
 param deploymentType string = 'GlobalStandard'
 
 @description('Optional. Name of the GPT model to deploy.')
-param gptModelName string = 'gpt-4.1-mini'
+param gptModelName string = 'gpt-5.4-mini'
 
 @description('Optional. Version of the GPT model to deploy.')
-param gptModelVersion string = '2025-04-14'
+param gptModelVersion string = '2026-03-17'
 
 @minValue(10)
 @description('Optional. Capacity of the GPT deployment (TPM in thousands).')

--- a/infra/scripts/build/build-and-push-acr.ps1
+++ b/infra/scripts/build/build-and-push-acr.ps1
@@ -1,0 +1,307 @@
+<#
+.SYNOPSIS
+    Post-deployment: build application container images with ACR remote build
+    (`az acr build`) and push them to the deployment-specific Azure Container
+    Registry, then repoint the App Services at the freshly built images.
+
+.DESCRIPTION
+    This is a SEPARATE, manual post-deployment step that runs AFTER the
+    infrastructure (including the dedicated ACR) has been provisioned.
+
+    Flow:
+      1. (Private networking only) Temporarily enable ACR public network access
+         so `az acr build` can upload the build context.
+      2. Remote-build + push each image server-side with `az acr build`
+         (no local Docker required).
+      3. Update each App Service to use the new image, keeping managed-identity
+         (AcrPull) authentication, and restart it.
+      4. (Private networking only) Disable ACR public network access again.
+
+    Run any other existing post-deployment scripts separately, after this one.
+
+.NOTES
+    Requires: Azure CLI (`az`) and an authenticated context (`az login`).
+    Does NOT require Docker to be installed locally.
+
+    When only -ResourceGroup is given, the ACR name, API/Web App Service names,
+    backend runtime, and private-networking state are auto-discovered from the RG.
+    With NO parameters, values are pulled from the local azd environment
+    (azd env get-values), if one is initialized. Any explicit parameter wins.
+
+    By default, individual `az` command output is suppressed and only progress
+    messages and errors are shown. Pass -VerboseOutput to see full command output.
+#>
+
+[CmdletBinding()]
+param (
+    [string]$ResourceGroup,
+    [string]$AcrName,
+    [string]$SubscriptionId,
+    [string]$ImageTag = "latest_v2",
+    [string]$ApiAppName,
+    [string]$WebAppName,
+    [ValidateSet("python", "dotnet")] [string]$BackendRuntimeStack = "python",
+    [switch]$PrivateNetworking,
+    [switch]$VerboseOutput
+)
+
+$ErrorActionPreference = "Stop"
+
+function Invoke-Az {
+    param([string[]]$Args)
+    # Suppress command stdout unless -VerboseOutput; errors (stderr) always show.
+    if ($VerboseOutput) {
+        & az @Args
+    }
+    else {
+        & az @Args 1>$null
+    }
+    if ($LASTEXITCODE -ne 0) {
+        throw "Azure CLI command failed: az $($Args -join ' ')"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Resolve paths (script lives in infra/scripts/build -> repo root is ../../..)
+# ---------------------------------------------------------------------------
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = (Resolve-Path (Join-Path $ScriptDir "..\..\..")).Path
+
+# ---------------------------------------------------------------------------
+# Fallback: pull any unset values from the local azd environment (if present).
+# Precedence: explicit parameter > azd env > RG-based discovery > default.
+# ---------------------------------------------------------------------------
+if (Get-Command azd -ErrorAction SilentlyContinue) {
+    $azdRaw = azd env get-values 2>$null
+    if ($LASTEXITCODE -eq 0 -and $azdRaw) {
+        $azdValues = @{}
+        foreach ($line in $azdRaw) {
+            if ($line -match '^\s*([A-Za-z0-9_]+)="?(.*?)"?\s*$') {
+                $azdValues[$Matches[1]] = $Matches[2]
+            }
+        }
+        function Get-AzdValue([string]$Key) {
+            if ($azdValues.ContainsKey($Key) -and -not [string]::IsNullOrWhiteSpace($azdValues[$Key])) {
+                return $azdValues[$Key]
+            }
+            return $null
+        }
+        if (-not $PSBoundParameters.ContainsKey('ResourceGroup'))      { $v = Get-AzdValue 'RESOURCE_GROUP_NAME';                if ($v) { $ResourceGroup = $v } }
+        if (-not $PSBoundParameters.ContainsKey('SubscriptionId'))     { $v = Get-AzdValue 'AZURE_SUBSCRIPTION_ID';              if ($v) { $SubscriptionId = $v } }
+        if (-not $PSBoundParameters.ContainsKey('AcrName'))            { $v = Get-AzdValue 'AZURE_ENV_CONTAINER_REGISTRY_NAME';  if ($v) { $AcrName = $v } }
+        if (-not $PSBoundParameters.ContainsKey('ApiAppName'))         { $v = Get-AzdValue 'API_APP_NAME';                       if ($v) { $ApiAppName = $v } }
+        if (-not $PSBoundParameters.ContainsKey('WebAppName'))         { $v = Get-AzdValue 'WEB_APP_NAME';                       if ($v) { $WebAppName = $v } }
+        if (-not $PSBoundParameters.ContainsKey('BackendRuntimeStack')){ $v = Get-AzdValue 'BACKEND_RUNTIME_STACK';              if ($v) { $BackendRuntimeStack = $v } }
+        if (-not $PSBoundParameters.ContainsKey('ImageTag'))          { $v = Get-AzdValue 'AZURE_ENV_IMAGE_TAG';                if ($v) { $ImageTag = $v } }
+        if ($ResourceGroup) { Write-Host "Loaded defaults from azd environment." }
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($ResourceGroup)) {
+    throw "ResourceGroup is required (pass -ResourceGroup or run inside an initialized azd environment)."
+}
+
+# ---------------------------------------------------------------------------
+# 1. Ensure Azure login + subscription
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "=== Step 1/4: Verifying Azure CLI login and discovering deployment ==="
+Write-Host "  Resource group ...: $ResourceGroup"
+$account = az account show 2>$null | ConvertFrom-Json
+if (-not $account) {
+    Write-Host "  Not logged in to Azure. Launching 'az login'..."
+    & az login | Out-Null
+}
+if ($SubscriptionId) {
+    Write-Host "  Setting subscription to '$SubscriptionId'..."
+    Invoke-Az @("account", "set", "--subscription", $SubscriptionId)
+}
+Write-Host "  Azure context ready."
+
+# ---------------------------------------------------------------------------
+# 1b. Auto-discover any values not supplied explicitly, from the resource group
+# ---------------------------------------------------------------------------
+$UsePrivateNetworking = $PrivateNetworking.IsPresent
+
+if ([string]::IsNullOrWhiteSpace($AcrName)) {
+    $AcrName = az acr list --resource-group $ResourceGroup --query "[0].name" -o tsv 2>$null
+    if ([string]::IsNullOrWhiteSpace($AcrName)) {
+        throw "No container registry found in resource group '$ResourceGroup'. Pass -AcrName explicitly."
+    }
+    Write-Host "  Discovered ACR ....: $AcrName"
+}
+
+if ([string]::IsNullOrWhiteSpace($ApiAppName)) {
+    $dotnetApp = az webapp list --resource-group $ResourceGroup --query "[?starts_with(name, 'api-cs-')].name | [0]" -o tsv 2>$null
+    if (-not [string]::IsNullOrWhiteSpace($dotnetApp)) {
+        $ApiAppName = $dotnetApp
+        $BackendRuntimeStack = "dotnet"
+    }
+    else {
+        $ApiAppName = az webapp list --resource-group $ResourceGroup --query "[?starts_with(name, 'api-') && !starts_with(name, 'api-cs-')].name | [0]" -o tsv 2>$null
+        $BackendRuntimeStack = "python"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($ApiAppName)) {
+        Write-Host "  Discovered API app : $ApiAppName (runtime: $BackendRuntimeStack)"
+    }
+    else {
+        Write-Host "  WARNING: No API App Service (api-* / api-cs-*) found in '$ResourceGroup'."
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($WebAppName)) {
+    $WebAppName = az webapp list --resource-group $ResourceGroup --query "[?starts_with(name, 'app-')].name | [0]" -o tsv 2>$null
+    if (-not [string]::IsNullOrWhiteSpace($WebAppName)) {
+        Write-Host "  Discovered Web app : $WebAppName"
+    }
+    else {
+        Write-Host "  WARNING: No Web App Service (app-*) found in '$ResourceGroup'."
+    }
+}
+
+# Auto-detect private networking from the ACR public-access state (unless explicit)
+if (-not $PrivateNetworking.IsPresent) {
+    $acrPublic = az acr show --name $AcrName --resource-group $ResourceGroup --query "publicNetworkAccess" -o tsv 2>$null
+    if ($acrPublic -eq "Disabled") {
+        $UsePrivateNetworking = $true
+        Write-Host "  Detected private networking (ACR public access is Disabled)."
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Compute derived values now that discovery is complete
+# ---------------------------------------------------------------------------
+$LoginServer = "$AcrName.azurecr.io"
+
+# Image definitions: name -> @{ Context; Dockerfile }
+$Images = @{
+    "da-app" = @{
+        Context    = (Join-Path $RepoRoot "src\App")
+        Dockerfile = "WebApp.Dockerfile"
+    }
+}
+if ($BackendRuntimeStack -eq "dotnet") {
+    $Images["da-api-dotnet"] = @{
+        Context    = (Join-Path $RepoRoot "src\api\dotnet")
+        Dockerfile = "CsApi.Dockerfile"
+    }
+    $BackendImage = "da-api-dotnet"
+}
+else {
+    $Images["da-api"] = @{
+        Context    = (Join-Path $RepoRoot "src\api\python")
+        Dockerfile = "ApiApp.Dockerfile"
+    }
+    $BackendImage = "da-api"
+}
+
+Write-Host "  ----------------------------------------------------------"
+Write-Host "  Resolved configuration:"
+Write-Host "    ACR ..............: $AcrName ($LoginServer)"
+Write-Host "    Image tag ........: $ImageTag"
+Write-Host "    Backend runtime ..: $BackendRuntimeStack"
+Write-Host "    API app ..........: $(if ($ApiAppName) { $ApiAppName } else { '<none>' })"
+Write-Host "    Web app ..........: $(if ($WebAppName) { $WebAppName } else { '<none>' })"
+Write-Host "    Private networking: $UsePrivateNetworking"
+Write-Host "    Verbose output ...: $($VerboseOutput.IsPresent)"
+
+# ---------------------------------------------------------------------------
+# 2. (Private networking) Temporarily enable ACR public access
+# ---------------------------------------------------------------------------
+Write-Host ""
+if ($UsePrivateNetworking) {
+    Write-Host "=== Step 2/4: Temporarily opening ACR '$AcrName' for remote build ==="
+    Write-Host "  App Services stay private - only the registry is opened for the build context upload."
+    Invoke-Az @("acr", "update", "--name", $AcrName, "--resource-group", $ResourceGroup, "--public-network-access", "Enabled", "--default-action", "Allow")
+    Write-Host "  Waiting 30s for network rule propagation..."
+    Start-Sleep -Seconds 30
+    Write-Host "  ACR public network access temporarily enabled."
+}
+else {
+    Write-Host "=== Step 2/4: Public networking mode - no ACR access toggle needed ==="
+}
+
+try {
+    # -----------------------------------------------------------------------
+    # 3. Remote build + push each image (server-side, no local Docker)
+    # -----------------------------------------------------------------------
+    Write-Host ""
+    Write-Host "=== Step 3/4: Building $($Images.Count) image(s) via ACR remote build (no local Docker) ==="
+    $buildIndex = 0
+    foreach ($imageName in $Images.Keys) {
+        $buildIndex++
+        $ctx = $Images[$imageName].Context
+        $dockerfile = $Images[$imageName].Dockerfile
+        $imageRef = "${imageName}:${ImageTag}"
+
+        Write-Host ""
+        Write-Host "  [$buildIndex/$($Images.Count)] Building '$imageRef'"
+        Write-Host "        context ...: $ctx"
+        Write-Host "        dockerfile : $dockerfile"
+        Invoke-Az @(
+            "acr", "build",
+            "--registry", $AcrName,
+            "--resource-group", $ResourceGroup,
+            "--image", $imageRef,
+            "--file", $dockerfile,
+            $ctx
+        )
+        Write-Host "  [$buildIndex/$($Images.Count)] Pushed '$LoginServer/$imageRef'"
+    }
+    Write-Host ""
+    Write-Host "  All images built and pushed."
+}
+finally {
+    # -----------------------------------------------------------------------
+    # Cleanup. (Private networking) Disable ACR public access again
+    # -----------------------------------------------------------------------
+    if ($UsePrivateNetworking) {
+        Write-Host ""
+        Write-Host "=== Cleanup: Re-locking ACR '$AcrName' (disabling public access) ==="
+        Invoke-Az @("acr", "update", "--name", $AcrName, "--resource-group", $ResourceGroup, "--public-network-access", "Disabled", "--default-action", "Deny")
+        Write-Host "  ACR public network access disabled again."
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 4. Update App Services to the newly built images (managed-identity pull)
+# ---------------------------------------------------------------------------
+Write-Host ""
+Write-Host "=== Step 4/4: Repointing App Services to the new images (managed-identity pull) ==="
+function Update-AppServiceImage {
+    param([string]$AppName, [string]$ImageName)
+    if ([string]::IsNullOrWhiteSpace($AppName)) {
+        Write-Host "  App name not provided for image '$ImageName' - skipping."
+        return
+    }
+    $fullImage = "$LoginServer/${ImageName}:${ImageTag}"
+    Write-Host ""
+    Write-Host "  Updating '$AppName' -> '$fullImage'"
+    Invoke-Az @(
+        "webapp", "config", "container", "set",
+        "--name", $AppName,
+        "--resource-group", $ResourceGroup,
+        "--container-image-name", $fullImage,
+        "--container-registry-url", "https://$LoginServer"
+    )
+    # Ensure the app keeps using its managed identity for the ACR pull.
+    Write-Host "  Enforcing managed-identity ACR authentication on '$AppName'..."
+    Invoke-Az @(
+        "resource", "update",
+        "--resource-group", $ResourceGroup,
+        "--name", $AppName,
+        "--resource-type", "Microsoft.Web/sites",
+        "--set", "properties.siteConfig.acrUseManagedIdentityCreds=true"
+    )
+    Write-Host "  Restarting '$AppName'..."
+    Invoke-Az @("webapp", "restart", "--name", $AppName, "--resource-group", $ResourceGroup)
+    Write-Host "  '$AppName' updated and restarted."
+}
+
+Update-AppServiceImage -AppName $ApiAppName -ImageName $BackendImage
+Update-AppServiceImage -AppName $WebAppName -ImageName "da-app"
+
+Write-Host ""
+Write-Host "=== All done! ==="
+Write-Host "  Images built in '$AcrName' and App Services repointed to managed-identity pulls."
+Write-Host "  Run any remaining post-deployment scripts separately, after this one."

--- a/infra/scripts/build/build-and-push-acr.ps1
+++ b/infra/scripts/build/build-and-push-acr.ps1
@@ -1,208 +1,202 @@
-<#
-.SYNOPSIS
-    Post-deployment: build application container images with ACR remote build
-    (`az acr build`) and push them to the deployment-specific Azure Container
-    Registry, then repoint the App Services at the freshly built images.
-
-.DESCRIPTION
-    This is a SEPARATE, manual post-deployment step that runs AFTER the
-    infrastructure (including the dedicated ACR) has been provisioned.
-
-    Flow:
-      1. (Private networking only) Temporarily enable ACR public network access
-         so `az acr build` can upload the build context.
-      2. Remote-build + push each image server-side with `az acr build`
-         (no local Docker required).
-      3. Update each App Service to use the new image, keeping managed-identity
-         (AcrPull) authentication, and restart it.
-      4. (Private networking only) Disable ACR public network access again.
-
-    Run any other existing post-deployment scripts separately, after this one.
-
-.NOTES
-    Requires: Azure CLI (`az`) and an authenticated context (`az login`).
-    Does NOT require Docker to be installed locally.
-
-    When -ResourceGroup is given, the ACR name, API/Web App Service names,
-    backend runtime, and private-networking state are auto-discovered from that RG
-    and the local azd environment is IGNORED. Any other explicit parameter still wins.
-    With NO parameters, values are pulled from the local azd environment
-    (azd env get-values), if one is initialized.
-
-    By default, individual `az` command output is suppressed and only progress
-    messages and errors are shown. Pass -VerboseOutput to see full command output.
-#>
+# ============================================================================
+# Post-deployment: build application container images with ACR remote build
+# (`az acr build`) and push them to the deployment-specific Azure Container
+# Registry, then repoint the App Services at the freshly built images.
+#
+# This is a SEPARATE, manual post-deployment step that runs AFTER the
+# infrastructure (including the dedicated ACR) has been provisioned.
+#
+# Flow:
+#   1. (Private networking only) Temporarily enable ACR public network access
+#      so `az acr build` can upload the build context.
+#   2. Remote-build + push each image server-side with `az acr build`
+#      (no local Docker required).
+#   3. Update each App Service to use the new image, keeping managed-identity
+#      (AcrPull) authentication, and restart it.
+#   4. (Private networking only) Disable ACR public network access again.
+#
+# Run any other existing post-deployment scripts separately, after this one.
+#
+# Requires: Azure CLI (`az`) and an authenticated context (`az login`).
+# Does NOT require Docker to be installed locally.
+# ============================================================================
 
 [CmdletBinding()]
 param (
-    [string]$ResourceGroup,
     [string]$AcrName,
-    [string]$SubscriptionId,
-    [string]$ImageTag = "latest_v2",
+    [string]$ResourceGroup,
+    [string]$Subscription,
+    [string]$ImageTag,
     [string]$ApiAppName,
     [string]$WebAppName,
-    [ValidateSet("python", "dotnet")] [string]$BackendRuntimeStack = "python",
+    [ValidateSet("python", "dotnet")]
+    [string]$BackendRuntime,
     [switch]$PrivateNetworking,
-    [switch]$VerboseOutput
+    [switch]$VerboseOutput,
+    [switch]$Help
 )
 
 $ErrorActionPreference = "Stop"
 
-# ---------------------------------------------------------------------------
-# UTF-8-safe `az` wrapper (mirrors the bash `az()` override).
-#
-# The Windows MSI `az` launcher runs `python.exe -IBm azure.cli`. The -I
-# (isolated) flag makes Python ignore PYTHON* env vars (PYTHONUTF8 /
-# PYTHONIOENCODING), so the `az acr build` log stream is encoded with the
-# console code page (cp1252) and crashes with a UnicodeEncodeError on any
-# non-ASCII build output. The `-X utf8` command-line flag is NOT blocked by
-# isolated mode, so we call the bundled python directly with -X utf8 when we
-# can find it; otherwise we fall back to the normal `az` launcher on PATH.
-#
-# Shadowing `az` as a function means EVERY az call in this script (login,
-# discovery queries, and the acr build) uses the UTF-8-safe invocation, exactly
-# like the bash version.
-# ---------------------------------------------------------------------------
-$script:AzPython = $null
-$script:AzReal = $null
-$azCmd = Get-Command az -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
-if ($azCmd) {
-    $script:AzReal = $azCmd.Source
-    $azDir = Split-Path -Parent $azCmd.Source
-    foreach ($cand in @(
-            (Join-Path $azDir "..\python.exe"),
-            (Join-Path $azDir "python.exe"))) {
-        if (Test-Path $cand) { $script:AzPython = (Resolve-Path $cand).Path; break }
-    }
+function Show-Usage {
+    @"
+Usage: build-and-push-acr.ps1 -ResourceGroup <rg> [options]
+
+Required:
+  -ResourceGroup <rg>          Resource group of the deployment
+
+Auto-discovery:
+  When -ResourceGroup is given, the ACR name, API/Web App Service names,
+  backend runtime, and private-networking state are auto-discovered from that RG
+  and the local azd environment is IGNORED. Any other explicit value still wins.
+  With NO arguments, values are pulled from the local azd environment
+  (azd env get-values), if one is initialized.
+
+Options:
+  -AcrName <name>              Target Azure Container Registry name
+  -Subscription <id>           Azure subscription ID
+  -ImageTag <tag>              Image tag (default: latest_v2)
+  -ApiAppName <name>           Backend App Service name to repoint
+  -WebAppName <name>           Frontend App Service name to repoint
+  -BackendRuntime <stack>      python|dotnet (default: auto-detect, else python)
+  -PrivateNetworking           Toggle ACR public access around the build
+  -VerboseOutput               Show full command output (default: only errors)
+  -Help                        Show this help
+"@
 }
 
-function az {
-    if ($script:AzPython) {
-        $env:AZ_INSTALLER = "MSI"
-        & $script:AzPython -X utf8 -B -m azure.cli @args
-    }
-    elseif ($script:AzReal) {
-        & $script:AzReal @args
-    }
-    else {
-        throw "Azure CLI ('az') was not found on PATH."
-    }
+if ($Help) {
+    Show-Usage
+    exit 0
 }
 
-# ---------------------------------------------------------------------------
-# Command runner: suppress stdout unless -VerboseOutput; errors always show.
-# (mirrors the bash `run()` wrapper, plus a non-zero exit-code guard.)
-# ---------------------------------------------------------------------------
-function Invoke-Az {
-    param([string[]]$Args)
-    if ($VerboseOutput) {
-        az @Args
-    }
-    else {
-        az @Args 1>$null
-    }
-    if ($LASTEXITCODE -ne 0) {
-        throw "Azure CLI command failed: az $($Args -join ' ')"
-    }
-}
+# ----------------------------------------------------------------------------
+# Track which values were supplied explicitly (explicit CLI arg always wins).
+# ----------------------------------------------------------------------------
+$ResourceGroupExplicit    = $PSBoundParameters.ContainsKey('ResourceGroup')
+$ImageTagExplicit         = $PSBoundParameters.ContainsKey('ImageTag')
+$BackendRuntimeExplicit   = $PSBoundParameters.ContainsKey('BackendRuntime')
+$PrivateNetworkingExplicit = $PSBoundParameters.ContainsKey('PrivateNetworking')
 
-# ---------------------------------------------------------------------------
-# Resolve paths (script lives in infra/scripts/build -> repo root is ../../..)
-# ---------------------------------------------------------------------------
-$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$RepoRoot = (Resolve-Path (Join-Path $ScriptDir "..\..\..")).Path
+if (-not $ImageTag)       { $ImageTag = "latest_v2" }
+if (-not $BackendRuntime) { $BackendRuntime = "python" }
+$PrivateNetworkingEnabled = [bool]$PrivateNetworking
 
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Fallback: pull any unset values from the local azd environment (if present).
-# This ONLY runs when the user did NOT pass -ResourceGroup. If a resource group
-# is supplied explicitly, the local azd environment is ignored entirely and
-# every value is taken from the parameters or discovered from that RG.
-# Precedence (no explicit RG): explicit parameter > azd env > RG-based discovery > default.
-# ---------------------------------------------------------------------------
-if ($PSBoundParameters.ContainsKey('ResourceGroup')) {
+# This ONLY runs when the user did NOT pass -ResourceGroup. If a resource
+# group is supplied explicitly, the local azd environment is ignored entirely
+# and every value is taken from the CLI args or discovered from that RG.
+# Precedence (no explicit RG): explicit CLI arg > azd env > RG-based discovery > default.
+# ----------------------------------------------------------------------------
+if ($ResourceGroupExplicit) {
     Write-Host "Resource group provided explicitly - ignoring local azd environment; all inputs will come from '$ResourceGroup'."
 }
 elseif (Get-Command azd -ErrorAction SilentlyContinue) {
-    $azdRaw = azd env get-values 2>$null
-    if ($LASTEXITCODE -eq 0 -and $azdRaw) {
-        $azdValues = @{}
-        foreach ($line in $azdRaw) {
-            if ($line -match '^\s*([A-Za-z0-9_]+)="?(.*?)"?\s*$') {
-                $azdValues[$Matches[1]] = $Matches[2]
+    $azdValues = & azd env get-values 2>$null
+    if ($azdValues) {
+        $azdMap = @{}
+        foreach ($line in $azdValues) {
+            if ($line -match '^\s*([^=]+)=(.*)$') {
+                $azdMap[$Matches[1].Trim()] = $Matches[2].Trim().Trim('"')
             }
         }
-        function Get-AzdValue([string]$Key) {
-            if ($azdValues.ContainsKey($Key) -and -not [string]::IsNullOrWhiteSpace($azdValues[$Key])) {
-                return $azdValues[$Key]
-            }
-            return $null
+        function Get-AzdValue([string]$key) { if ($azdMap.ContainsKey($key)) { $azdMap[$key] } else { "" } }
+
+        if (-not $ResourceGroup) { $ResourceGroup = Get-AzdValue "RESOURCE_GROUP_NAME" }
+        if (-not $Subscription)  { $Subscription  = Get-AzdValue "AZURE_SUBSCRIPTION_ID" }
+        if (-not $AcrName)       { $AcrName       = Get-AzdValue "AZURE_ENV_CONTAINER_REGISTRY_NAME" }
+        if (-not $ApiAppName)    { $ApiAppName    = Get-AzdValue "API_APP_NAME" }
+        if (-not $WebAppName)    { $WebAppName    = Get-AzdValue "WEB_APP_NAME" }
+        if (-not $BackendRuntimeExplicit) {
+            $azdRuntime = Get-AzdValue "BACKEND_RUNTIME_STACK"
+            if ($azdRuntime) { $BackendRuntime = $azdRuntime }
         }
-        if (-not $PSBoundParameters.ContainsKey('ResourceGroup'))      { $v = Get-AzdValue 'RESOURCE_GROUP_NAME';                if ($v) { $ResourceGroup = $v } }
-        if (-not $PSBoundParameters.ContainsKey('SubscriptionId'))     { $v = Get-AzdValue 'AZURE_SUBSCRIPTION_ID';              if ($v) { $SubscriptionId = $v } }
-        if (-not $PSBoundParameters.ContainsKey('AcrName'))            { $v = Get-AzdValue 'AZURE_ENV_CONTAINER_REGISTRY_NAME';  if ($v) { $AcrName = $v } }
-        if (-not $PSBoundParameters.ContainsKey('ApiAppName'))         { $v = Get-AzdValue 'API_APP_NAME';                       if ($v) { $ApiAppName = $v } }
-        if (-not $PSBoundParameters.ContainsKey('WebAppName'))         { $v = Get-AzdValue 'WEB_APP_NAME';                       if ($v) { $WebAppName = $v } }
-        if (-not $PSBoundParameters.ContainsKey('BackendRuntimeStack')){ $v = Get-AzdValue 'BACKEND_RUNTIME_STACK';              if ($v) { $BackendRuntimeStack = $v } }
-        if (-not $PSBoundParameters.ContainsKey('ImageTag'))          { $v = Get-AzdValue 'AZURE_ENV_IMAGE_TAG';                if ($v) { $ImageTag = $v } }
+        if (-not $ImageTagExplicit) {
+            $azdTag = Get-AzdValue "AZURE_ENV_IMAGE_TAG"
+            if ($azdTag) { $ImageTag = $azdTag }
+        }
         if ($ResourceGroup) { Write-Host "Loaded defaults from azd environment." }
     }
 }
 
-if ([string]::IsNullOrWhiteSpace($ResourceGroup)) {
-    throw "ResourceGroup is required (pass -ResourceGroup or run inside an initialized azd environment)."
+if (-not $ResourceGroup) {
+    Write-Error "ERROR: -ResourceGroup is required (or run inside an initialized azd environment)."
+    Show-Usage
+    exit 1
 }
 
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+# Resolve paths (script lives in infra/scripts/build -> repo root is ../../..)
+# ----------------------------------------------------------------------------
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot  = (Resolve-Path (Join-Path $ScriptDir "..\..\..")).Path
+
+# ----------------------------------------------------------------------------
+# Command runner: suppress stdout unless -VerboseOutput; errors always show.
+# ----------------------------------------------------------------------------
+function Invoke-Run {
+    param([Parameter(Mandatory)][scriptblock]$Command)
+    if ($VerboseOutput) {
+        & $Command
+    }
+    else {
+        & $Command | Out-Null
+    }
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code $LASTEXITCODE."
+    }
+}
+
+# ----------------------------------------------------------------------------
 # 1. Ensure Azure login + subscription
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 Write-Host ""
 Write-Host "=== Step 1/4: Verifying Azure CLI login and discovering deployment ==="
 Write-Host "  Resource group ...: $ResourceGroup"
-$account = az account show 2>$null | ConvertFrom-Json
-if (-not $account) {
+az account show 2>$null | Out-Null
+if ($LASTEXITCODE -ne 0) {
     Write-Host "  Not logged in to Azure. Launching 'az login'..."
-    & az login | Out-Null
+    az login | Out-Null
 }
-if ($SubscriptionId) {
-    Write-Host "  Setting subscription to '$SubscriptionId'..."
-    Invoke-Az @("account", "set", "--subscription", $SubscriptionId)
+if ($Subscription) {
+    Write-Host "  Setting subscription to '$Subscription'..."
+    Invoke-Run { az account set --subscription $Subscription }
 }
-Write-Host "  Azure context ready."
 
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # 1b. Auto-discover any values not supplied explicitly, from the resource group
-# ---------------------------------------------------------------------------
-$UsePrivateNetworking = $PrivateNetworking.IsPresent
-
-if ([string]::IsNullOrWhiteSpace($AcrName)) {
+# ----------------------------------------------------------------------------
+if (-not $AcrName) {
     $AcrName = az acr list --resource-group $ResourceGroup --query "[0].name" -o tsv 2>$null
-    if ([string]::IsNullOrWhiteSpace($AcrName)) {
-        throw "No container registry found in resource group '$ResourceGroup'. Pass -AcrName explicitly."
+    if (-not $AcrName) {
+        Write-Error "ERROR: No container registry found in resource group '$ResourceGroup'. Pass -AcrName explicitly."
+        exit 1
     }
     Write-Host "  Discovered ACR ....: $AcrName"
 }
 
-if ([string]::IsNullOrWhiteSpace($ApiAppName)) {
+if (-not $ApiAppName) {
     $dotnetApp = az webapp list --resource-group $ResourceGroup --query "[?starts_with(name, 'api-cs-')].name | [0]" -o tsv 2>$null
-    if (-not [string]::IsNullOrWhiteSpace($dotnetApp)) {
+    if ($dotnetApp) {
         $ApiAppName = $dotnetApp
-        $BackendRuntimeStack = "dotnet"
+        $BackendRuntime = "dotnet"
     }
     else {
         $ApiAppName = az webapp list --resource-group $ResourceGroup --query "[?starts_with(name, 'api-') && !starts_with(name, 'api-cs-')].name | [0]" -o tsv 2>$null
-        $BackendRuntimeStack = "python"
+        $BackendRuntime = "python"
     }
-    if (-not [string]::IsNullOrWhiteSpace($ApiAppName)) {
-        Write-Host "  Discovered API app : $ApiAppName (runtime: $BackendRuntimeStack)"
+    if ($ApiAppName) {
+        Write-Host "  Discovered API app : $ApiAppName (runtime: $BackendRuntime)"
     }
     else {
         Write-Host "  WARNING: No API App Service (api-* / api-cs-*) found in '$ResourceGroup'."
     }
 }
 
-if ([string]::IsNullOrWhiteSpace($WebAppName)) {
+if (-not $WebAppName) {
     $WebAppName = az webapp list --resource-group $ResourceGroup --query "[?starts_with(name, 'app-')].name | [0]" -o tsv 2>$null
-    if (-not [string]::IsNullOrWhiteSpace($WebAppName)) {
+    if ($WebAppName) {
         Write-Host "  Discovered Web app : $WebAppName"
     }
     else {
@@ -211,99 +205,109 @@ if ([string]::IsNullOrWhiteSpace($WebAppName)) {
 }
 
 # Auto-detect private networking from the ACR public-access state (unless explicit)
-if (-not $PrivateNetworking.IsPresent) {
+if (-not $PrivateNetworkingExplicit) {
     $acrPublic = az acr show --name $AcrName --resource-group $ResourceGroup --query "publicNetworkAccess" -o tsv 2>$null
     if ($acrPublic -eq "Disabled") {
-        $UsePrivateNetworking = $true
+        $PrivateNetworkingEnabled = $true
         Write-Host "  Detected private networking (ACR public access is Disabled)."
     }
 }
 
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Compute derived values now that discovery is complete
-# ---------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 $LoginServer = "$AcrName.azurecr.io"
 
-# Image definitions: name -> @{ Context; Dockerfile }
-$Images = @{
-    "da-app" = @{
-        Context    = (Join-Path $RepoRoot "src\App")
-        Dockerfile = "WebApp.Dockerfile"
-    }
-}
-if ($BackendRuntimeStack -eq "dotnet") {
-    $Images["da-api-dotnet"] = @{
-        Context    = (Join-Path $RepoRoot "src\api\dotnet")
-        Dockerfile = "CsApi.Dockerfile"
-    }
+# Image definitions (name|context|dockerfile)
+$Images = @(
+    [pscustomobject]@{ Name = "da-app"; Context = "$RepoRoot/src/App"; Dockerfile = "WebApp.Dockerfile" }
+)
+if ($BackendRuntime -eq "dotnet") {
+    $Images += [pscustomobject]@{ Name = "da-api-dotnet"; Context = "$RepoRoot/src/api/dotnet"; Dockerfile = "CsApi.Dockerfile" }
     $BackendImage = "da-api-dotnet"
 }
 else {
-    $Images["da-api"] = @{
-        Context    = (Join-Path $RepoRoot "src\api\python")
-        Dockerfile = "ApiApp.Dockerfile"
-    }
+    $Images += [pscustomobject]@{ Name = "da-api"; Context = "$RepoRoot/src/api/python"; Dockerfile = "ApiApp.Dockerfile" }
     $BackendImage = "da-api"
 }
+
+$apiAppDisplay = if ($ApiAppName) { $ApiAppName } else { "<none>" }
+$webAppDisplay = if ($WebAppName) { $WebAppName } else { "<none>" }
 
 Write-Host "  ----------------------------------------------------------"
 Write-Host "  Resolved configuration:"
 Write-Host "    ACR ..............: $AcrName ($LoginServer)"
 Write-Host "    Image tag ........: $ImageTag"
-Write-Host "    Backend runtime ..: $BackendRuntimeStack"
-Write-Host "    API app ..........: $(if ($ApiAppName) { $ApiAppName } else { '<none>' })"
-Write-Host "    Web app ..........: $(if ($WebAppName) { $WebAppName } else { '<none>' })"
-Write-Host "    Private networking: $UsePrivateNetworking"
-Write-Host "    Verbose output ...: $($VerboseOutput.IsPresent)"
+Write-Host "    Backend runtime ..: $BackendRuntime"
+Write-Host "    API app ..........: $apiAppDisplay"
+Write-Host "    Web app ..........: $webAppDisplay"
+Write-Host "    Private networking: $PrivateNetworkingEnabled"
+Write-Host "    Verbose output ...: $([bool]$VerboseOutput)"
+Write-Host "  Azure context ready."
 
-# ---------------------------------------------------------------------------
-# 2. (Private networking) Temporarily enable ACR public access
-# ---------------------------------------------------------------------------
-Write-Host ""
-if ($UsePrivateNetworking) {
-    Write-Host "=== Step 2/4: Temporarily opening ACR '$AcrName' for remote build ==="
-    Write-Host "  App Services stay private - only the registry is opened for the build context upload."
-    # Public network access cannot be enabled while the export policy is disabled,
-    # so enable exports first, then open the public endpoint.
-    Invoke-Az @("acr", "update", "--name", $AcrName, "--resource-group", $ResourceGroup, "--allow-exports", "true")
-    Invoke-Az @("acr", "update", "--name", $AcrName, "--resource-group", $ResourceGroup, "--public-network-enabled", "true", "--default-action", "Allow")
-    Write-Host "  Waiting 30s for network rule propagation..."
-    Start-Sleep -Seconds 30
-    Write-Host "  ACR public network access temporarily enabled."
-}
-else {
-    Write-Host "=== Step 2/4: Public networking mode - no ACR access toggle needed ==="
+# ----------------------------------------------------------------------------
+# Cleanup: (Private networking) re-lock ACR on exit
+# ----------------------------------------------------------------------------
+function Disable-PublicAccess {
+    if ($PrivateNetworkingEnabled) {
+        Write-Host ""
+        Write-Host "=== Cleanup: Re-locking ACR '$AcrName' (disabling public access) ==="
+        Invoke-Run { az acr update --name $AcrName --resource-group $ResourceGroup `
+                --public-network-enabled false --default-action Deny }
+        Write-Host "  ACR public network access disabled again."
+        # Restore the export policy to its locked-down (disabled) state. This can
+        # only be disabled once public network access is off (done above).
+        Invoke-Run { az acr update --name $AcrName --resource-group $ResourceGroup `
+                --allow-exports false }
+        Write-Host "  ACR export policy re-disabled."
+    }
 }
 
 try {
-    # -----------------------------------------------------------------------
+    # ------------------------------------------------------------------------
+    # 2. (Private networking) Temporarily enable ACR public access
+    # ------------------------------------------------------------------------
+    Write-Host ""
+    if ($PrivateNetworkingEnabled) {
+        Write-Host "=== Step 2/4: Temporarily opening ACR '$AcrName' for remote build ==="
+        Write-Host "  App Services stay private - only the registry is opened for the build context upload."
+        # Public network access cannot be enabled while the export policy is disabled,
+        # so enable exports first, then open the public endpoint.
+        Invoke-Run { az acr update --name $AcrName --resource-group $ResourceGroup `
+                --allow-exports true }
+        Invoke-Run { az acr update --name $AcrName --resource-group $ResourceGroup `
+                --public-network-enabled true --default-action Allow }
+        Write-Host "  Waiting 30s for network rule propagation..."
+        Start-Sleep -Seconds 30
+        Write-Host "  ACR public network access temporarily enabled."
+    }
+    else {
+        Write-Host "=== Step 2/4: Public networking mode - no ACR access toggle needed ==="
+    }
+
+    # ------------------------------------------------------------------------
     # 3. Remote build + push each image (server-side, no local Docker)
-    # -----------------------------------------------------------------------
+    # ------------------------------------------------------------------------
     Write-Host ""
     Write-Host "=== Step 3/4: Building $($Images.Count) image(s) via ACR remote build (no local Docker) ==="
     $buildIndex = 0
-    foreach ($imageName in $Images.Keys) {
+    foreach ($entry in $Images) {
         $buildIndex++
-        $ctx = $Images[$imageName].Context
-        $dockerfile = $Images[$imageName].Dockerfile
-        $imageRef = "${imageName}:${ImageTag}"
-
+        $imageRef = "$($entry.Name):$ImageTag"
         Write-Host ""
         Write-Host "  [$buildIndex/$($Images.Count)] Building '$imageRef'"
-        Write-Host "        context ...: $ctx"
-        Write-Host "        dockerfile : $dockerfile"
+        Write-Host "        context ...: $($entry.Context)"
+        Write-Host "        dockerfile : $($entry.Dockerfile)"
         # Run from within the context so `--file` resolves relative to it (az acr
         # build validates the dockerfile path against the current directory).
-        Push-Location $ctx
+        Push-Location $entry.Context
         try {
-            Invoke-Az @(
-                "acr", "build",
-                "--registry", $AcrName,
-                "--resource-group", $ResourceGroup,
-                "--image", $imageRef,
-                "--file", $dockerfile,
-                "."
-            )
+            Invoke-Run { az acr build `
+                    --registry $AcrName `
+                    --resource-group $ResourceGroup `
+                    --image $imageRef `
+                    --file $entry.Dockerfile `
+                    . }
         }
         finally {
             Pop-Location
@@ -312,62 +316,49 @@ try {
     }
     Write-Host ""
     Write-Host "  All images built and pushed."
+
+    # ------------------------------------------------------------------------
+    # 4. Update App Services to the newly built images (managed-identity pull)
+    # ------------------------------------------------------------------------
+    Write-Host ""
+    Write-Host "=== Step 4/4: Repointing App Services to the new images (managed-identity pull) ==="
+    function Update-AppServiceImage {
+        param(
+            [string]$AppName,
+            [string]$ImageName
+        )
+        if (-not $AppName) {
+            Write-Host "  App name not provided for image '$ImageName' - skipping."
+            return
+        }
+        $fullImage = "$LoginServer/$($ImageName):$ImageTag"
+        Write-Host ""
+        Write-Host "  Updating '$AppName' -> '$fullImage'"
+        Invoke-Run { az webapp config container set `
+                --name $AppName `
+                --resource-group $ResourceGroup `
+                --container-image-name $fullImage `
+                --container-registry-url "https://$LoginServer" }
+        # Ensure the app keeps using its managed identity for the ACR pull.
+        Write-Host "  Enforcing managed-identity ACR authentication on '$AppName'..."
+        Invoke-Run { az resource update `
+                --resource-group $ResourceGroup `
+                --name $AppName `
+                --resource-type "Microsoft.Web/sites" `
+                --set properties.siteConfig.acrUseManagedIdentityCreds=true }
+        Write-Host "  Restarting '$AppName'..."
+        Invoke-Run { az webapp restart --name $AppName --resource-group $ResourceGroup }
+        Write-Host "  '$AppName' updated and restarted."
+    }
+
+    Update-AppServiceImage -AppName $ApiAppName -ImageName $BackendImage
+    Update-AppServiceImage -AppName $WebAppName -ImageName "da-app"
+
+    Write-Host ""
+    Write-Host "=== All done! ==="
+    Write-Host "  Images built in '$AcrName' and App Services repointed to managed-identity pulls."
+    Write-Host "  Run any remaining post-deployment scripts separately, after this one."
 }
 finally {
-    # -----------------------------------------------------------------------
-    # Cleanup. (Private networking) Disable ACR public access again
-    # -----------------------------------------------------------------------
-    if ($UsePrivateNetworking) {
-        Write-Host ""
-        Write-Host "=== Cleanup: Re-locking ACR '$AcrName' (disabling public access) ==="
-        Invoke-Az @("acr", "update", "--name", $AcrName, "--resource-group", $ResourceGroup, "--public-network-enabled", "false", "--default-action", "Deny")
-        Write-Host "  ACR public network access disabled again."
-        # Restore the export policy to its locked-down (disabled) state. This can
-        # only be disabled once public network access is off (done above).
-        Invoke-Az @("acr", "update", "--name", $AcrName, "--resource-group", $ResourceGroup, "--allow-exports", "false")
-        Write-Host "  ACR export policy re-disabled."
-    }
+    Disable-PublicAccess
 }
-
-# ---------------------------------------------------------------------------
-# 4. Update App Services to the newly built images (managed-identity pull)
-# ---------------------------------------------------------------------------
-Write-Host ""
-Write-Host "=== Step 4/4: Repointing App Services to the new images (managed-identity pull) ==="
-function Update-AppServiceImage {
-    param([string]$AppName, [string]$ImageName)
-    if ([string]::IsNullOrWhiteSpace($AppName)) {
-        Write-Host "  App name not provided for image '$ImageName' - skipping."
-        return
-    }
-    $fullImage = "$LoginServer/${ImageName}:${ImageTag}"
-    Write-Host ""
-    Write-Host "  Updating '$AppName' -> '$fullImage'"
-    Invoke-Az @(
-        "webapp", "config", "container", "set",
-        "--name", $AppName,
-        "--resource-group", $ResourceGroup,
-        "--container-image-name", $fullImage,
-        "--container-registry-url", "https://$LoginServer"
-    )
-    # Ensure the app keeps using its managed identity for the ACR pull.
-    Write-Host "  Enforcing managed-identity ACR authentication on '$AppName'..."
-    Invoke-Az @(
-        "resource", "update",
-        "--resource-group", $ResourceGroup,
-        "--name", $AppName,
-        "--resource-type", "Microsoft.Web/sites",
-        "--set", "properties.siteConfig.acrUseManagedIdentityCreds=true"
-    )
-    Write-Host "  Restarting '$AppName'..."
-    Invoke-Az @("webapp", "restart", "--name", $AppName, "--resource-group", $ResourceGroup)
-    Write-Host "  '$AppName' updated and restarted."
-}
-
-Update-AppServiceImage -AppName $ApiAppName -ImageName $BackendImage
-Update-AppServiceImage -AppName $WebAppName -ImageName "da-app"
-
-Write-Host ""
-Write-Host "=== All done! ==="
-Write-Host "  Images built in '$AcrName' and App Services repointed to managed-identity pulls."
-Write-Host "  Run any remaining post-deployment scripts separately, after this one."

--- a/infra/scripts/build/build-and-push-acr.ps1
+++ b/infra/scripts/build/build-and-push-acr.ps1
@@ -23,10 +23,11 @@
     Requires: Azure CLI (`az`) and an authenticated context (`az login`).
     Does NOT require Docker to be installed locally.
 
-    When only -ResourceGroup is given, the ACR name, API/Web App Service names,
-    backend runtime, and private-networking state are auto-discovered from the RG.
+    When -ResourceGroup is given, the ACR name, API/Web App Service names,
+    backend runtime, and private-networking state are auto-discovered from that RG
+    and the local azd environment is IGNORED. Any other explicit parameter still wins.
     With NO parameters, values are pulled from the local azd environment
-    (azd env get-values), if one is initialized. Any explicit parameter wins.
+    (azd env get-values), if one is initialized.
 
     By default, individual `az` command output is suppressed and only progress
     messages and errors are shown. Pass -VerboseOutput to see full command output.
@@ -113,9 +114,15 @@ $RepoRoot = (Resolve-Path (Join-Path $ScriptDir "..\..\..")).Path
 
 # ---------------------------------------------------------------------------
 # Fallback: pull any unset values from the local azd environment (if present).
-# Precedence: explicit parameter > azd env > RG-based discovery > default.
+# This ONLY runs when the user did NOT pass -ResourceGroup. If a resource group
+# is supplied explicitly, the local azd environment is ignored entirely and
+# every value is taken from the parameters or discovered from that RG.
+# Precedence (no explicit RG): explicit parameter > azd env > RG-based discovery > default.
 # ---------------------------------------------------------------------------
-if (Get-Command azd -ErrorAction SilentlyContinue) {
+if ($PSBoundParameters.ContainsKey('ResourceGroup')) {
+    Write-Host "Resource group provided explicitly - ignoring local azd environment; all inputs will come from '$ResourceGroup'."
+}
+elseif (Get-Command azd -ErrorAction SilentlyContinue) {
     $azdRaw = azd env get-values 2>$null
     if ($LASTEXITCODE -eq 0 -and $azdRaw) {
         $azdValues = @{}

--- a/infra/scripts/build/build-and-push-acr.ps1
+++ b/infra/scripts/build/build-and-push-acr.ps1
@@ -263,7 +263,10 @@ Write-Host ""
 if ($UsePrivateNetworking) {
     Write-Host "=== Step 2/4: Temporarily opening ACR '$AcrName' for remote build ==="
     Write-Host "  App Services stay private - only the registry is opened for the build context upload."
-    Invoke-Az @("acr", "update", "--name", $AcrName, "--resource-group", $ResourceGroup, "--public-network-access", "Enabled", "--default-action", "Allow")
+    # Public network access cannot be enabled while the export policy is disabled,
+    # so enable exports first, then open the public endpoint.
+    Invoke-Az @("acr", "update", "--name", $AcrName, "--resource-group", $ResourceGroup, "--allow-exports", "true")
+    Invoke-Az @("acr", "update", "--name", $AcrName, "--resource-group", $ResourceGroup, "--public-network-enabled", "true", "--default-action", "Allow")
     Write-Host "  Waiting 30s for network rule propagation..."
     Start-Sleep -Seconds 30
     Write-Host "  ACR public network access temporarily enabled."
@@ -317,8 +320,12 @@ finally {
     if ($UsePrivateNetworking) {
         Write-Host ""
         Write-Host "=== Cleanup: Re-locking ACR '$AcrName' (disabling public access) ==="
-        Invoke-Az @("acr", "update", "--name", $AcrName, "--resource-group", $ResourceGroup, "--public-network-access", "Disabled", "--default-action", "Deny")
+        Invoke-Az @("acr", "update", "--name", $AcrName, "--resource-group", $ResourceGroup, "--public-network-enabled", "false", "--default-action", "Deny")
         Write-Host "  ACR public network access disabled again."
+        # Restore the export policy to its locked-down (disabled) state. This can
+        # only be disabled once public network access is off (done above).
+        Invoke-Az @("acr", "update", "--name", $AcrName, "--resource-group", $ResourceGroup, "--allow-exports", "false")
+        Write-Host "  ACR export policy re-disabled."
     }
 }
 

--- a/infra/scripts/build/build-and-push-acr.ps1
+++ b/infra/scripts/build/build-and-push-acr.ps1
@@ -47,14 +47,58 @@ param (
 
 $ErrorActionPreference = "Stop"
 
-function Invoke-Az {
-    param([string[]]$Args)
-    # Suppress command stdout unless -VerboseOutput; errors (stderr) always show.
-    if ($VerboseOutput) {
-        & az @Args
+# ---------------------------------------------------------------------------
+# UTF-8-safe `az` wrapper (mirrors the bash `az()` override).
+#
+# The Windows MSI `az` launcher runs `python.exe -IBm azure.cli`. The -I
+# (isolated) flag makes Python ignore PYTHON* env vars (PYTHONUTF8 /
+# PYTHONIOENCODING), so the `az acr build` log stream is encoded with the
+# console code page (cp1252) and crashes with a UnicodeEncodeError on any
+# non-ASCII build output. The `-X utf8` command-line flag is NOT blocked by
+# isolated mode, so we call the bundled python directly with -X utf8 when we
+# can find it; otherwise we fall back to the normal `az` launcher on PATH.
+#
+# Shadowing `az` as a function means EVERY az call in this script (login,
+# discovery queries, and the acr build) uses the UTF-8-safe invocation, exactly
+# like the bash version.
+# ---------------------------------------------------------------------------
+$script:AzPython = $null
+$script:AzReal = $null
+$azCmd = Get-Command az -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($azCmd) {
+    $script:AzReal = $azCmd.Source
+    $azDir = Split-Path -Parent $azCmd.Source
+    foreach ($cand in @(
+            (Join-Path $azDir "..\python.exe"),
+            (Join-Path $azDir "python.exe"))) {
+        if (Test-Path $cand) { $script:AzPython = (Resolve-Path $cand).Path; break }
+    }
+}
+
+function az {
+    if ($script:AzPython) {
+        $env:AZ_INSTALLER = "MSI"
+        & $script:AzPython -X utf8 -B -m azure.cli @args
+    }
+    elseif ($script:AzReal) {
+        & $script:AzReal @args
     }
     else {
-        & az @Args 1>$null
+        throw "Azure CLI ('az') was not found on PATH."
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Command runner: suppress stdout unless -VerboseOutput; errors always show.
+# (mirrors the bash `run()` wrapper, plus a non-zero exit-code guard.)
+# ---------------------------------------------------------------------------
+function Invoke-Az {
+    param([string[]]$Args)
+    if ($VerboseOutput) {
+        az @Args
+    }
+    else {
+        az @Args 1>$null
     }
     if ($LASTEXITCODE -ne 0) {
         throw "Azure CLI command failed: az $($Args -join ' ')"
@@ -238,14 +282,22 @@ try {
         Write-Host "  [$buildIndex/$($Images.Count)] Building '$imageRef'"
         Write-Host "        context ...: $ctx"
         Write-Host "        dockerfile : $dockerfile"
-        Invoke-Az @(
-            "acr", "build",
-            "--registry", $AcrName,
-            "--resource-group", $ResourceGroup,
-            "--image", $imageRef,
-            "--file", $dockerfile,
-            $ctx
-        )
+        # Run from within the context so `--file` resolves relative to it (az acr
+        # build validates the dockerfile path against the current directory).
+        Push-Location $ctx
+        try {
+            Invoke-Az @(
+                "acr", "build",
+                "--registry", $AcrName,
+                "--resource-group", $ResourceGroup,
+                "--image", $imageRef,
+                "--file", $dockerfile,
+                "."
+            )
+        }
+        finally {
+            Pop-Location
+        }
         Write-Host "  [$buildIndex/$($Images.Count)] Pushed '$LoginServer/$imageRef'"
     }
     Write-Host ""

--- a/infra/scripts/build/build-and-push-acr.sh
+++ b/infra/scripts/build/build-and-push-acr.sh
@@ -24,6 +24,38 @@
 set -euo pipefail
 
 # ----------------------------------------------------------------------------
+# UTF-8-safe `az` wrapper.
+#
+# The Windows MSI `az` launcher runs `python.exe -IBm azure.cli`. The -I
+# (isolated) flag makes Python ignore PYTHON* env vars (PYTHONUTF8 /
+# PYTHONIOENCODING), so on Git Bash the `az acr build` log stream is encoded
+# with the console code page (cp1252) and crashes with a UnicodeEncodeError on
+# any non-ASCII build output.
+#
+# We can't override that via env vars, but the `-X utf8` command-line flag is
+# NOT blocked by isolated mode. So when the bundled python is found next to the
+# az launcher we call it directly with -X utf8; otherwise we fall back to the
+# normal `az` on PATH (Linux/macOS, where UTF-8 locales avoid the issue).
+# ----------------------------------------------------------------------------
+_AZ_PY=""
+_az_launcher="$(command -v az || true)"
+if [[ -n "$_az_launcher" ]]; then
+    _az_dir="$(cd "$(dirname "$_az_launcher")" && pwd)"
+    for _cand in "$_az_dir/../python.exe" "$_az_dir/python.exe"; do
+        if [[ -f "$_cand" ]]; then _AZ_PY="$_cand"; break; fi
+    done
+fi
+
+az() {
+    if [[ -n "$_AZ_PY" ]]; then
+        AZ_INSTALLER=MSI "$_AZ_PY" -X utf8 -Bm azure.cli "$@"
+    else
+        command az "$@"
+    fi
+}
+
+
+# ----------------------------------------------------------------------------
 # Argument parsing
 # ----------------------------------------------------------------------------
 ACR_NAME=""
@@ -119,7 +151,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 # ----------------------------------------------------------------------------
-# Command runner: suppress stdout unless --verbose; errors (stderr) always show
+# Command runner: suppress stdout unless --verbose; errors (stderr) always show.
 # ----------------------------------------------------------------------------
 run() {
     if [[ "$VERBOSE" == "true" ]]; then
@@ -257,12 +289,14 @@ for entry in "${IMAGES[@]}"; do
     echo "  [$build_index/${#IMAGES[@]}] Building '$image_ref'"
     echo "        context ...: $context"
     echo "        dockerfile : $dockerfile"
-    run az acr build \
+    # Run from within the context so `--file` resolves relative to it (az acr
+    # build validates the dockerfile path against the current directory).
+    ( cd "$context" && run az acr build \
         --registry "$ACR_NAME" \
         --resource-group "$RESOURCE_GROUP" \
         --image "$image_ref" \
         --file "$dockerfile" \
-        "$context"
+        . )
     echo "  [$build_index/${#IMAGES[@]}] Pushed '${LOGIN_SERVER}/${image_ref}'"
 done
 echo ""

--- a/infra/scripts/build/build-and-push-acr.sh
+++ b/infra/scripts/build/build-and-push-acr.sh
@@ -60,6 +60,7 @@ az() {
 # ----------------------------------------------------------------------------
 ACR_NAME=""
 RESOURCE_GROUP=""
+RESOURCE_GROUP_EXPLICIT="false"
 SUBSCRIPTION_ID=""
 IMAGE_TAG="latest_v2"
 API_APP_NAME=""
@@ -79,10 +80,11 @@ Required:
   --resource-group <rg>        Resource group of the deployment
 
 Auto-discovery:
-  When only --resource-group is given, the ACR name, API/Web App Service names,
-  backend runtime, and private-networking state are auto-discovered from the RG.
+  When --resource-group is given, the ACR name, API/Web App Service names,
+  backend runtime, and private-networking state are auto-discovered from that RG
+  and the local azd environment is IGNORED. Any other explicit value still wins.
   With NO arguments, values are pulled from the local azd environment
-  (azd env get-values), if one is initialized. Any explicit value wins.
+  (azd env get-values), if one is initialized.
 
 Options:
   --acr-name <name>            Target Azure Container Registry name
@@ -100,7 +102,7 @@ EOF
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --acr-name) ACR_NAME="$2"; shift 2 ;;
-        --resource-group) RESOURCE_GROUP="$2"; shift 2 ;;
+        --resource-group) RESOURCE_GROUP="$2"; RESOURCE_GROUP_EXPLICIT="true"; shift 2 ;;
         --subscription) SUBSCRIPTION_ID="$2"; shift 2 ;;
         --image-tag) IMAGE_TAG="$2"; IMAGE_TAG_EXPLICIT="true"; shift 2 ;;
         --api-app-name) API_APP_NAME="$2"; shift 2 ;;
@@ -115,9 +117,14 @@ done
 
 # ----------------------------------------------------------------------------
 # Fallback: pull any unset values from the local azd environment (if present).
-# Precedence: explicit CLI arg > azd env > RG-based discovery > default.
+# This ONLY runs when the user did NOT pass --resource-group. If a resource
+# group is supplied explicitly, the local azd environment is ignored entirely
+# and every value is taken from the CLI args or discovered from that RG.
+# Precedence (no explicit RG): explicit CLI arg > azd env > RG-based discovery > default.
 # ----------------------------------------------------------------------------
-if command -v azd > /dev/null 2>&1; then
+if [[ "$RESOURCE_GROUP_EXPLICIT" == "true" ]]; then
+    echo "Resource group provided explicitly - ignoring local azd environment; all inputs will come from '$RESOURCE_GROUP'."
+elif command -v azd > /dev/null 2>&1; then
     AZD_VALUES="$(azd env get-values 2>/dev/null || true)"
     if [[ -n "$AZD_VALUES" ]]; then
         azd_get() { echo "$AZD_VALUES" | grep -E "^$1=" | head -n1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//'; }

--- a/infra/scripts/build/build-and-push-acr.sh
+++ b/infra/scripts/build/build-and-push-acr.sh
@@ -263,8 +263,13 @@ disable_public_access() {
         echo ""
         echo "=== Cleanup: Re-locking ACR '$ACR_NAME' (disabling public access) ==="
         run az acr update --name "$ACR_NAME" --resource-group "$RESOURCE_GROUP" \
-            --public-network-access Disabled --default-action Deny
+            --public-network-enabled false --default-action Deny
         echo "  ACR public network access disabled again."
+        # Restore the export policy to its locked-down (disabled) state. This can
+        # only be disabled once public network access is off (done above).
+        run az acr update --name "$ACR_NAME" --resource-group "$RESOURCE_GROUP" \
+            --allow-exports false
+        echo "  ACR export policy re-disabled."
     fi
 }
 trap disable_public_access EXIT
@@ -273,8 +278,12 @@ echo ""
 if [[ "$PRIVATE_NETWORKING" == "true" ]]; then
     echo "=== Step 2/4: Temporarily opening ACR '$ACR_NAME' for remote build ==="
     echo "  App Services stay private - only the registry is opened for the build context upload."
+    # Public network access cannot be enabled while the export policy is disabled,
+    # so enable exports first, then open the public endpoint.
     run az acr update --name "$ACR_NAME" --resource-group "$RESOURCE_GROUP" \
-        --public-network-access Enabled --default-action Allow
+        --allow-exports true
+    run az acr update --name "$ACR_NAME" --resource-group "$RESOURCE_GROUP" \
+        --public-network-enabled true --default-action Allow
     echo "  Waiting 30s for network rule propagation..."
     sleep 30
     echo "  ACR public network access temporarily enabled."

--- a/infra/scripts/build/build-and-push-acr.sh
+++ b/infra/scripts/build/build-and-push-acr.sh
@@ -1,0 +1,309 @@
+#!/bin/bash
+# ============================================================================
+# Post-deployment: build application container images with ACR remote build
+# (`az acr build`) and push them to the deployment-specific Azure Container
+# Registry, then repoint the App Services at the freshly built images.
+#
+# This is a SEPARATE, manual post-deployment step that runs AFTER the
+# infrastructure (including the dedicated ACR) has been provisioned.
+#
+# Flow:
+#   1. (Private networking only) Temporarily enable ACR public network access
+#      so `az acr build` can upload the build context.
+#   2. Remote-build + push each image server-side with `az acr build`
+#      (no local Docker required).
+#   3. Update each App Service to use the new image, keeping managed-identity
+#      (AcrPull) authentication, and restart it.
+#   4. (Private networking only) Disable ACR public network access again.
+#
+# Run any other existing post-deployment scripts separately, after this one.
+#
+# Requires: Azure CLI (`az`) and an authenticated context (`az login`).
+# Does NOT require Docker to be installed locally.
+# ============================================================================
+set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# Argument parsing
+# ----------------------------------------------------------------------------
+ACR_NAME=""
+RESOURCE_GROUP=""
+SUBSCRIPTION_ID=""
+IMAGE_TAG="latest_v2"
+API_APP_NAME=""
+WEB_APP_NAME=""
+BACKEND_RUNTIME_STACK="python"
+BACKEND_RUNTIME_EXPLICIT="false"
+IMAGE_TAG_EXPLICIT="false"
+PRIVATE_NETWORKING="false"
+PRIVATE_NETWORKING_EXPLICIT="false"
+VERBOSE="false"
+
+usage() {
+    cat <<EOF
+Usage: build-and-push-acr.sh --resource-group <rg> [options]
+
+Required:
+  --resource-group <rg>        Resource group of the deployment
+
+Auto-discovery:
+  When only --resource-group is given, the ACR name, API/Web App Service names,
+  backend runtime, and private-networking state are auto-discovered from the RG.
+  With NO arguments, values are pulled from the local azd environment
+  (azd env get-values), if one is initialized. Any explicit value wins.
+
+Options:
+  --acr-name <name>            Target Azure Container Registry name
+  --subscription <id>          Azure subscription ID
+  --image-tag <tag>            Image tag (default: latest_v2)
+  --api-app-name <name>        Backend App Service name to repoint
+  --web-app-name <name>        Frontend App Service name to repoint
+  --backend-runtime <stack>    python|dotnet (default: auto-detect, else python)
+  --private-networking         Toggle ACR public access around the build
+  --verbose                    Show full command output (default: only errors)
+  -h, --help                   Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --acr-name) ACR_NAME="$2"; shift 2 ;;
+        --resource-group) RESOURCE_GROUP="$2"; shift 2 ;;
+        --subscription) SUBSCRIPTION_ID="$2"; shift 2 ;;
+        --image-tag) IMAGE_TAG="$2"; IMAGE_TAG_EXPLICIT="true"; shift 2 ;;
+        --api-app-name) API_APP_NAME="$2"; shift 2 ;;
+        --web-app-name) WEB_APP_NAME="$2"; shift 2 ;;
+        --backend-runtime) BACKEND_RUNTIME_STACK="$2"; BACKEND_RUNTIME_EXPLICIT="true"; shift 2 ;;
+        --private-networking) PRIVATE_NETWORKING="true"; PRIVATE_NETWORKING_EXPLICIT="true"; shift ;;
+        --verbose) VERBOSE="true"; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+# ----------------------------------------------------------------------------
+# Fallback: pull any unset values from the local azd environment (if present).
+# Precedence: explicit CLI arg > azd env > RG-based discovery > default.
+# ----------------------------------------------------------------------------
+if command -v azd > /dev/null 2>&1; then
+    AZD_VALUES="$(azd env get-values 2>/dev/null || true)"
+    if [[ -n "$AZD_VALUES" ]]; then
+        azd_get() { echo "$AZD_VALUES" | grep -E "^$1=" | head -n1 | cut -d= -f2- | sed -e 's/^"//' -e 's/"$//'; }
+        [[ -z "$RESOURCE_GROUP" ]]        && RESOURCE_GROUP="$(azd_get RESOURCE_GROUP_NAME)"
+        [[ -z "$SUBSCRIPTION_ID" ]]       && SUBSCRIPTION_ID="$(azd_get AZURE_SUBSCRIPTION_ID)"
+        [[ -z "$ACR_NAME" ]]              && ACR_NAME="$(azd_get AZURE_ENV_CONTAINER_REGISTRY_NAME)"
+        [[ -z "$API_APP_NAME" ]]          && API_APP_NAME="$(azd_get API_APP_NAME)"
+        [[ -z "$WEB_APP_NAME" ]]          && WEB_APP_NAME="$(azd_get WEB_APP_NAME)"
+        if [[ "$BACKEND_RUNTIME_EXPLICIT" == "false" ]]; then
+            azd_runtime="$(azd_get BACKEND_RUNTIME_STACK)"
+            [[ -n "$azd_runtime" ]] && BACKEND_RUNTIME_STACK="$azd_runtime"
+        fi
+        if [[ "$IMAGE_TAG_EXPLICIT" == "false" ]]; then
+            azd_tag="$(azd_get AZURE_ENV_IMAGE_TAG)"
+            [[ -n "$azd_tag" ]] && IMAGE_TAG="$azd_tag"
+        fi
+        [[ -n "$RESOURCE_GROUP" ]] && echo "Loaded defaults from azd environment."
+    fi
+fi
+
+if [[ -z "$RESOURCE_GROUP" ]]; then
+    echo "ERROR: --resource-group is required (or run inside an initialized azd environment)." >&2
+    usage
+    exit 1
+fi
+
+# ----------------------------------------------------------------------------
+# Resolve paths (script lives in infra/scripts/build -> repo root is ../../..)
+# ----------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# ----------------------------------------------------------------------------
+# Command runner: suppress stdout unless --verbose; errors (stderr) always show
+# ----------------------------------------------------------------------------
+run() {
+    if [[ "$VERBOSE" == "true" ]]; then
+        "$@"
+    else
+        "$@" > /dev/null
+    fi
+}
+
+# ----------------------------------------------------------------------------
+# 1. Ensure Azure login + subscription
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Step 1/4: Verifying Azure CLI login and discovering deployment ==="
+echo "  Resource group ...: $RESOURCE_GROUP"
+if ! az account show > /dev/null 2>&1; then
+    echo "  Not logged in to Azure. Launching 'az login'..."
+    az login
+fi
+if [[ -n "$SUBSCRIPTION_ID" ]]; then
+    echo "  Setting subscription to '$SUBSCRIPTION_ID'..."
+    run az account set --subscription "$SUBSCRIPTION_ID"
+fi
+
+# ----------------------------------------------------------------------------
+# 1b. Auto-discover any values not supplied explicitly, from the resource group
+# ----------------------------------------------------------------------------
+if [[ -z "$ACR_NAME" ]]; then
+    ACR_NAME="$(az acr list --resource-group "$RESOURCE_GROUP" --query "[0].name" -o tsv 2>/dev/null || true)"
+    if [[ -z "$ACR_NAME" ]]; then
+        echo "ERROR: No container registry found in resource group '$RESOURCE_GROUP'. Pass --acr-name explicitly." >&2
+        exit 1
+    fi
+    echo "  Discovered ACR ....: $ACR_NAME"
+fi
+
+if [[ -z "$API_APP_NAME" ]]; then
+    dotnet_app="$(az webapp list --resource-group "$RESOURCE_GROUP" --query "[?starts_with(name, 'api-cs-')].name | [0]" -o tsv 2>/dev/null || true)"
+    if [[ -n "$dotnet_app" ]]; then
+        API_APP_NAME="$dotnet_app"
+        BACKEND_RUNTIME_STACK="dotnet"
+    else
+        API_APP_NAME="$(az webapp list --resource-group "$RESOURCE_GROUP" --query "[?starts_with(name, 'api-') && !starts_with(name, 'api-cs-')].name | [0]" -o tsv 2>/dev/null || true)"
+        BACKEND_RUNTIME_STACK="python"
+    fi
+    if [[ -n "$API_APP_NAME" ]]; then
+        echo "  Discovered API app : $API_APP_NAME (runtime: $BACKEND_RUNTIME_STACK)"
+    else
+        echo "  WARNING: No API App Service (api-* / api-cs-*) found in '$RESOURCE_GROUP'."
+    fi
+fi
+
+if [[ -z "$WEB_APP_NAME" ]]; then
+    WEB_APP_NAME="$(az webapp list --resource-group "$RESOURCE_GROUP" --query "[?starts_with(name, 'app-')].name | [0]" -o tsv 2>/dev/null || true)"
+    if [[ -n "$WEB_APP_NAME" ]]; then
+        echo "  Discovered Web app : $WEB_APP_NAME"
+    else
+        echo "  WARNING: No Web App Service (app-*) found in '$RESOURCE_GROUP'."
+    fi
+fi
+
+# Auto-detect private networking from the ACR public-access state (unless explicit)
+if [[ "$PRIVATE_NETWORKING_EXPLICIT" == "false" ]]; then
+    acr_public="$(az acr show --name "$ACR_NAME" --resource-group "$RESOURCE_GROUP" --query "publicNetworkAccess" -o tsv 2>/dev/null || true)"
+    if [[ "$acr_public" == "Disabled" ]]; then
+        PRIVATE_NETWORKING="true"
+        echo "  Detected private networking (ACR public access is Disabled)."
+    fi
+fi
+
+# ----------------------------------------------------------------------------
+# Compute derived values now that discovery is complete
+# ----------------------------------------------------------------------------
+LOGIN_SERVER="${ACR_NAME}.azurecr.io"
+
+# Image definitions (name|context|dockerfile)
+IMAGES=("da-app|${REPO_ROOT}/src/App|WebApp.Dockerfile")
+if [[ "$BACKEND_RUNTIME_STACK" == "dotnet" ]]; then
+    IMAGES+=("da-api-dotnet|${REPO_ROOT}/src/api/dotnet|CsApi.Dockerfile")
+    BACKEND_IMAGE="da-api-dotnet"
+else
+    IMAGES+=("da-api|${REPO_ROOT}/src/api/python|ApiApp.Dockerfile")
+    BACKEND_IMAGE="da-api"
+fi
+
+echo "  ----------------------------------------------------------"
+echo "  Resolved configuration:"
+echo "    ACR ..............: $ACR_NAME ($LOGIN_SERVER)"
+echo "    Image tag ........: $IMAGE_TAG"
+echo "    Backend runtime ..: $BACKEND_RUNTIME_STACK"
+echo "    API app ..........: ${API_APP_NAME:-<none>}"
+echo "    Web app ..........: ${WEB_APP_NAME:-<none>}"
+echo "    Private networking: $PRIVATE_NETWORKING"
+echo "    Verbose output ...: $VERBOSE"
+echo "  Azure context ready."
+
+# ----------------------------------------------------------------------------
+# 2. (Private networking) Temporarily enable ACR public access
+# ----------------------------------------------------------------------------
+disable_public_access() {
+    if [[ "$PRIVATE_NETWORKING" == "true" ]]; then
+        echo ""
+        echo "=== Cleanup: Re-locking ACR '$ACR_NAME' (disabling public access) ==="
+        run az acr update --name "$ACR_NAME" --resource-group "$RESOURCE_GROUP" \
+            --public-network-access Disabled --default-action Deny
+        echo "  ACR public network access disabled again."
+    fi
+}
+trap disable_public_access EXIT
+
+echo ""
+if [[ "$PRIVATE_NETWORKING" == "true" ]]; then
+    echo "=== Step 2/4: Temporarily opening ACR '$ACR_NAME' for remote build ==="
+    echo "  App Services stay private - only the registry is opened for the build context upload."
+    run az acr update --name "$ACR_NAME" --resource-group "$RESOURCE_GROUP" \
+        --public-network-access Enabled --default-action Allow
+    echo "  Waiting 30s for network rule propagation..."
+    sleep 30
+    echo "  ACR public network access temporarily enabled."
+else
+    echo "=== Step 2/4: Public networking mode - no ACR access toggle needed ==="
+fi
+
+# ----------------------------------------------------------------------------
+# 3. Remote build + push each image (server-side, no local Docker)
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Step 3/4: Building ${#IMAGES[@]} image(s) via ACR remote build (no local Docker) ==="
+build_index=0
+for entry in "${IMAGES[@]}"; do
+    build_index=$((build_index + 1))
+    IFS='|' read -r image_name context dockerfile <<< "$entry"
+    image_ref="${image_name}:${IMAGE_TAG}"
+    echo ""
+    echo "  [$build_index/${#IMAGES[@]}] Building '$image_ref'"
+    echo "        context ...: $context"
+    echo "        dockerfile : $dockerfile"
+    run az acr build \
+        --registry "$ACR_NAME" \
+        --resource-group "$RESOURCE_GROUP" \
+        --image "$image_ref" \
+        --file "$dockerfile" \
+        "$context"
+    echo "  [$build_index/${#IMAGES[@]}] Pushed '${LOGIN_SERVER}/${image_ref}'"
+done
+echo ""
+echo "  All images built and pushed."
+
+# ----------------------------------------------------------------------------
+# 4. Update App Services to the newly built images (managed-identity pull)
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Step 4/4: Repointing App Services to the new images (managed-identity pull) ==="
+update_app_service_image() {
+    local app_name="$1"
+    local image_name="$2"
+    if [[ -z "$app_name" ]]; then
+        echo "  App name not provided for image '$image_name' - skipping."
+        return
+    fi
+    local full_image="${LOGIN_SERVER}/${image_name}:${IMAGE_TAG}"
+    echo ""
+    echo "  Updating '$app_name' -> '$full_image'"
+    run az webapp config container set \
+        --name "$app_name" \
+        --resource-group "$RESOURCE_GROUP" \
+        --container-image-name "$full_image" \
+        --container-registry-url "https://${LOGIN_SERVER}"
+    # Ensure the app keeps using its managed identity for the ACR pull.
+    echo "  Enforcing managed-identity ACR authentication on '$app_name'..."
+    run az resource update \
+        --resource-group "$RESOURCE_GROUP" \
+        --name "$app_name" \
+        --resource-type "Microsoft.Web/sites" \
+        --set properties.siteConfig.acrUseManagedIdentityCreds=true
+    echo "  Restarting '$app_name'..."
+    run az webapp restart --name "$app_name" --resource-group "$RESOURCE_GROUP"
+    echo "  '$app_name' updated and restarted."
+}
+
+update_app_service_image "$API_APP_NAME" "$BACKEND_IMAGE"
+update_app_service_image "$WEB_APP_NAME" "da-app"
+
+echo ""
+echo "=== All done! ==="
+echo "  Images built in '$ACR_NAME' and App Services repointed to managed-identity pulls."
+echo "  Run any remaining post-deployment scripts separately, after this one."

--- a/infra/scripts/post-provision/04_create_agent.py
+++ b/infra/scripts/post-provision/04_create_agent.py
@@ -68,7 +68,7 @@ from azure.ai.projects.models import (
 
 # Azure services - from azd environment
 ENDPOINT = os.getenv("AZURE_AI_AGENT_ENDPOINT")
-MODEL = os.getenv("AZURE_CHAT_MODEL") or os.getenv("AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME", "gpt-4.1-mini")
+MODEL = os.getenv("AZURE_CHAT_MODEL") or os.getenv("AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME", "gpt-5.4-mini")
 
 # Search mode
 USE_KNOWLEDGE_BASE = args.use_knowledge_base or True


### PR DESCRIPTION
## Purpose
This pull request introduces several significant infrastructure improvements, primarily focused on enhancing container image deployment security and flexibility, and updating the default GPT model version. The main changes are the introduction of a dedicated per-deployment Azure Container Registry (ACR) with private networking support, secure managed identity-based image pulls for App Services, and updates to default GPT model parameters across documentation and templates.

**Container Registry & Deployment Security**

* Added a dedicated per-deployment Azure Container Registry (`container-registry.bicep`), with support for private endpoints, dynamic naming, and a public placeholder image for initial provisioning. The registry is now referenced throughout the deployment, and its outputs are surfaced for downstream use. [[1]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfR208-R215) [[2]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfR796-R821) [[3]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfR1037-R1045)
* App Services (backend and frontend) now use a public placeholder image at provision time and are configured to pull images from the dedicated ACR using managed identities. This improves security by eliminating the need for admin credentials and supports private networking scenarios. [[1]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL815-R852) [[2]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL881-R919) [[3]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL945-R989) [[4]](diffhunk://#diff-82aa43dbbca87296ed8df346a8abc34df18380756cdd6657941ca89390d83b24R81-R83) [[5]](diffhunk://#diff-82aa43dbbca87296ed8df346a8abc34df18380756cdd6657941ca89390d83b24R113)
* Role assignments are extended to grant the AcrPull role to both backend and frontend App Service managed identities, ensuring they can pull images from the dedicated ACR. [[1]](diffhunk://#diff-abcac15d68464f1e22aed5daae942ad37d1a9a2a5f96fdc127f0bf48bf5771d0R31-R33) [[2]](diffhunk://#diff-abcac15d68464f1e22aed5daae942ad37d1a9a2a5f96fdc127f0bf48bf5771d0R48-R50) [[3]](diffhunk://#diff-abcac15d68464f1e22aed5daae942ad37d1a9a2a5f96fdc127f0bf48bf5771d0R71) [[4]](diffhunk://#diff-abcac15d68464f1e22aed5daae942ad37d1a9a2a5f96fdc127f0bf48bf5771d0R94-R97) [[5]](diffhunk://#diff-abcac15d68464f1e22aed5daae942ad37d1a9a2a5f96fdc127f0bf48bf5771d0R245-R270) [[6]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfR1016-R1017)

**Model & Documentation Updates**

* Default GPT model name and version updated from `gpt-4.1-mini`/`2025-04-14` to `gpt-5.4-mini`/`2026-03-17` across Bicep templates and all related documentation, ensuring consistency and use of the latest model. [[1]](diffhunk://#diff-2e319e20f66e2cd84d3764f457565dbc3fe39c15edc9d7c05801ff16c423598aL20-R21) [[2]](diffhunk://#diff-2afa876cbd4555ebfa7f423b650916642673e68d9d91b430ba3c72539e127ae5L187-R188) [[3]](diffhunk://#diff-2afa876cbd4555ebfa7f423b650916642673e68d9d91b430ba3c72539e127ae5L203-R203) [[4]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL82-R82) [[5]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfL95-R98)
* Documentation and parameters updated to reflect the new default GPT model and version, and quota recommendations adjusted accordingly. [[1]](diffhunk://#diff-2afa876cbd4555ebfa7f423b650916642673e68d9d91b430ba3c72539e127ae5L203-R203) [[2]](diffhunk://#diff-2e319e20f66e2cd84d3764f457565dbc3fe39c15edc9d7c05801ff16c423598aL20-R21)

**Networking & Private Access**

* Private DNS zone and index entries added for Azure Container Registry, enabling private endpoint scenarios for the registry. [[1]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfR284) [[2]](diffhunk://#diff-0c8d399dfddf2946045933947879b1e60a1fc5942a4e38e50a35f7ef28406bbfR295)
* Container Registry module now enables ARM-audience AAD token policy by default, which is required for App Service managed identity-based image pulls. [[1]](diffhunk://#diff-3983269102b875f24bf715e9828a649d8bebdb48155ad0f64f6f16d8a7cf22caR32-R35) [[2]](diffhunk://#diff-3983269102b875f24bf715e9828a649d8bebdb48155ad0f64f6f16d8a7cf22caR120)

These changes collectively improve security, flexibility, and maintainability of the deployment process, while keeping the infrastructure up to date with the latest Azure and OpenAI capabilities.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->

