### PR TITLE
fix: Fix authentication error and address Copilot comments

### DIFF
--- a/infra/scripts/post-provision/setup_app_authentication.ps1
+++ b/infra/scripts/post-provision/setup_app_authentication.ps1
@@ -267,9 +267,15 @@ if ($requestedAccessTokenVersion -ne "2") {
     $tokenVersionTempFile = [System.IO.Path]::GetTempFileName()
     $tokenVersionBody | Out-File -FilePath $tokenVersionTempFile -Encoding utf8 -NoNewline
     az rest --method PATCH --uri "https://graph.microsoft.com/v1.0/applications/$appObjectId" --body "@$tokenVersionTempFile" --headers "Content-Type=application/json" --output none 2>$null
+    $patchExitCode = $LASTEXITCODE
     Remove-Item $tokenVersionTempFile -Force -ErrorAction SilentlyContinue
 
-    Write-Host "  requestedAccessTokenVersion set to 2" -ForegroundColor Green
+    if ($patchExitCode -eq 0) {
+        Write-Host "  requestedAccessTokenVersion set to 2" -ForegroundColor Green
+    } else {
+        Write-Host "  ERROR: Failed to set requestedAccessTokenVersion to 2 (Graph PATCH failed)." -ForegroundColor Red
+        exit 1
+    }
 } else {
     Write-Host "  requestedAccessTokenVersion already set to 2" -ForegroundColor Gray
 }

--- a/infra/scripts/post-provision/setup_app_authentication.ps1
+++ b/infra/scripts/post-provision/setup_app_authentication.ps1
@@ -183,6 +183,7 @@ Write-Host ""
 Write-Host "[2/9] Getting Azure subscription info..." -ForegroundColor Yellow
 $subscriptionId = (az account show --query id -o tsv)
 $tenantId = (az account show --query tenantId -o tsv)
+$openIdIssuer = "https://login.microsoftonline.com/$tenantId/v2.0"
 
 if (-not $subscriptionId -or -not $tenantId) {
     Write-Host "  ERROR: Failed to retrieve subscription or tenant info." -ForegroundColor Red
@@ -251,6 +252,27 @@ Write-Host "  Exposing API scope for OBO..." -ForegroundColor Gray
 # Set Application ID URI
 $appIdUri = "api://$clientId"
 az ad app update --id $clientId --identifier-uris $appIdUri --output none 2>$null
+
+# Ensure the app issues v2 access tokens so EasyAuth validation matches the
+# configured login.microsoftonline.com/v2.0 issuer.
+$requestedAccessTokenVersion = az ad app show --id $clientId --query "api.requestedAccessTokenVersion" -o tsv 2>$null
+if ($requestedAccessTokenVersion -ne "2") {
+    $appObjectId = az ad app show --id $clientId --query "id" -o tsv
+    $tokenVersionBody = @{
+        api = @{
+            requestedAccessTokenVersion = 2
+        }
+    } | ConvertTo-Json -Depth 5
+
+    $tokenVersionTempFile = [System.IO.Path]::GetTempFileName()
+    $tokenVersionBody | Out-File -FilePath $tokenVersionTempFile -Encoding utf8 -NoNewline
+    az rest --method PATCH --uri "https://graph.microsoft.com/v1.0/applications/$appObjectId" --body "@$tokenVersionTempFile" --headers "Content-Type=application/json" --output none 2>$null
+    Remove-Item $tokenVersionTempFile -Force -ErrorAction SilentlyContinue
+
+    Write-Host "  requestedAccessTokenVersion set to 2" -ForegroundColor Green
+} else {
+    Write-Host "  requestedAccessTokenVersion already set to 2" -ForegroundColor Gray
+}
 
 # Check if scope already exists
 $existingScopes = az ad app show --id $clientId --query "api.oauth2PermissionScopes" -o json 2>$null | ConvertFrom-Json
@@ -503,12 +525,16 @@ $authConfig = @{
             requireAuthentication = $true
             unauthenticatedClientAction = "RedirectToLoginPage"
             redirectToProvider = "azureactivedirectory"
+            excludedPaths = @(
+                "/api/*"
+                "/history/*"
+            )
         }
         identityProviders = @{
             azureActiveDirectory = @{
                 enabled = $true
                 registration = @{
-                    openIdIssuer = "https://sts.windows.net/$tenantId/v2.0"
+                    openIdIssuer = $openIdIssuer
                     clientId = $clientId
                     clientSecretSettingName = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
                 }
@@ -602,7 +628,7 @@ if ($ApiAppName) {
                 azureActiveDirectory = @{
                     enabled = $true
                     registration = @{
-                        openIdIssuer = "https://sts.windows.net/$tenantId/v2.0"
+                        openIdIssuer = $openIdIssuer
                         clientId = $clientId
                         clientSecretSettingName = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
                     }

--- a/infra/scripts/post-provision/setup_app_authentication.ps1
+++ b/infra/scripts/post-provision/setup_app_authentication.ps1
@@ -531,10 +531,6 @@ $authConfig = @{
             requireAuthentication = $true
             unauthenticatedClientAction = "RedirectToLoginPage"
             redirectToProvider = "azureactivedirectory"
-            excludedPaths = @(
-                "/api/*"
-                "/history/*"
-            )
         }
         identityProviders = @{
             azureActiveDirectory = @{
@@ -550,6 +546,12 @@ $authConfig = @{
                         "api://$clientId"
                         $clientId
                     )
+                    # IMPORTANT: without this, Azure defaults allowedApplications to an empty
+                    # array, which EasyAuth treats as a DENY-ALL policy ("this principal does
+                    # not match any of the allowed applications") - rejecting every valid token.
+                    defaultAuthorizationPolicy = @{
+                        allowedApplications = @($clientId)
+                    }
                 }
                 login = @{
                     # Request scopes needed for OBO flow
@@ -617,17 +619,22 @@ if ($ApiAppName) {
         exit 1
     }
     
-    # API auth config - AllowAnonymous mode for cross-domain compatibility
-    # Platform is enabled to parse tokens, but auth is not required
-    # This allows the frontend to send X-ZUMO-AUTH tokens without EasyAuth blocking cross-origin requests
+    # API auth config - authentication is REQUIRED (do not skip/exclude auth on the API)
+    # Platform is enabled and validates the bearer token forwarded by the frontend's
+    # reverse proxy. "Return401" is the Microsoft-recommended unauthenticatedClientAction
+    # for APIs (as opposed to "RedirectToLoginPage", which is for browser apps) - it
+    # rejects requests without a valid token/session instead of silently allowing them
+    # through, which is required for auth_utils.py's reliance on the
+    # x-ms-client-principal-id / x-ms-token-aad-access-token headers that EasyAuth injects
+    # only when it has actually validated the caller.
     $apiAuthConfig = @{
         properties = @{
             platform = @{
                 enabled = $true
             }
             globalValidation = @{
-                requireAuthentication = $false  # Don't require auth - API handles token validation
-                unauthenticatedClientAction = "AllowAnonymous"  # Allow anonymous for cross-domain
+                requireAuthentication = $true  # Require auth - do not skip validation
+                unauthenticatedClientAction = "Return401"  # Correct action for APIs (no HTML redirect)
                 redirectToProvider = "azureactivedirectory"
             }
             identityProviders = @{
@@ -643,6 +650,11 @@ if ($ApiAppName) {
                             "api://$clientId"
                             $clientId
                         )
+                        # See matching comment on the frontend config above - required to avoid
+                        # EasyAuth's deny-all default when allowedApplications is left unset.
+                        defaultAuthorizationPolicy = @{
+                            allowedApplications = @($clientId)
+                        }
                     }
                 }
             }
@@ -665,7 +677,7 @@ if ($ApiAppName) {
     Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
     
     if ($apiExitCode -eq 0) {
-        Write-Host "  API authentication configured successfully (AllowAnonymous mode)" -ForegroundColor Green
+        Write-Host "  API authentication configured successfully (authentication required)" -ForegroundColor Green
         Write-Host "  OBO environment variables set on API" -ForegroundColor Green
     } else {
         Write-Host "  Warning: Failed to configure API authentication" -ForegroundColor Yellow

--- a/src/App/env.sh
+++ b/src/App/env.sh
@@ -16,6 +16,7 @@ location /api/ {
     proxy_set_header X-Real-IP \$remote_addr;
     proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_set_header Authorization \$http_authorization;
 
     proxy_ssl_server_name on;
 
@@ -35,6 +36,7 @@ location /history/ {
     proxy_set_header X-Real-IP \$remote_addr;
     proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_set_header Authorization \$http_authorization;
 
     proxy_ssl_server_name on;
 

--- a/src/App/src/api/api.ts
+++ b/src/App/src/api/api.ts
@@ -24,15 +24,17 @@ httpClient.addRequestInterceptor((config) => {
     (config.headers as any)['X-Ms-Client-Principal-Id'] = userId;
   }
   // Add access token for cross-domain auth and OBO flow
-  // EasyAuth accepts Bearer token in Authorization header for cross-origin requests
+  // EasyAuth accepts a raw AAD Bearer token in the Authorization header for cross-origin
+  // requests. Do NOT also send it as X-ZUMO-AUTH: that header is reserved for EasyAuth's own
+  // self-issued session token (whose iss/aud is the site's own URL), not a raw AAD access
+  // token. Sending the AAD token there causes EasyAuth's own token validator to fail with an
+  // issuer/audience mismatch exception and reject the request outright.
   const accessToken = getAccessToken();
 
   if (accessToken && config.headers) {
     (config.headers as any)['Authorization'] = `Bearer ${accessToken}`;
-    // Also send as X-ZUMO-AUTH for App Service EasyAuth compatibility
-    (config.headers as any)['X-ZUMO-AUTH'] = accessToken;
   } else if (process.env.NODE_ENV === 'development') {
-    console.log('[Request] NO token - Authorization and X-ZUMO-AUTH headers NOT added');
+    console.log('[Request] NO token - Authorization header NOT added');
   }
   return config;
 });

--- a/src/api/python/auth/auth_utils.py
+++ b/src/api/python/auth/auth_utils.py
@@ -26,14 +26,17 @@ def get_authenticated_user_details(request_headers):
     user_object["aad_id_token"] = raw_user_object.get("x-ms-token-aad-id-token")
 
     # Access token for OBO (On-Behalf-Of) flow - needed for Work IQ Teams
-    # Try multiple sources: EasyAuth header first, then custom header from frontend
     easyauth_token = normalized_headers.get("x-ms-token-aad-access-token")
     zumo_token = normalized_headers.get("x-zumo-auth")
+    authorization = normalized_headers.get("authorization", "")
+    scheme, _, bearer_token = authorization.partition(" ")
 
     if easyauth_token:
         user_object["aad_access_token"] = easyauth_token
     elif zumo_token:
         user_object["aad_access_token"] = zumo_token
+    elif scheme.lower() == "bearer" and bearer_token.strip():
+        user_object["aad_access_token"] = bearer_token.strip()
     else:
         user_object["aad_access_token"] = None
 


### PR DESCRIPTION
## Purpose
This pull request strengthens and standardizes authentication for both the frontend and API, ensuring correct Azure AD (EasyAuth) integration and preventing common misconfigurations. The changes enforce required authentication for the API, ensure the correct OpenID issuer and access token version are set, and fix header handling in both the reverse proxy and client code to support secure cross-origin authentication.

**Authentication and Azure AD Integration:**

* The API authentication configuration now requires authentication (`requireAuthentication = $true`) and uses `Return401` for unauthenticated requests, ensuring only validated requests are processed and preventing silent failures. [[1]](diffhunk://#diff-bc3a70ba28e4b7962d42d894dd244361fd3657378d42225d1d5da5f91c13009aL588-R644) [[2]](diffhunk://#diff-bc3a70ba28e4b7962d42d894dd244361fd3657378d42225d1d5da5f91c13009aL636-R680)
* The OpenID issuer is now set using the correct v2.0 endpoint (`$openIdIssuer`), and the Azure AD app's `requestedAccessTokenVersion` is explicitly set to 2 to ensure compatibility with EasyAuth token validation. [[1]](diffhunk://#diff-bc3a70ba28e4b7962d42d894dd244361fd3657378d42225d1d5da5f91c13009aR186) [[2]](diffhunk://#diff-bc3a70ba28e4b7962d42d894dd244361fd3657378d42225d1d5da5f91c13009aR256-R282) [[3]](diffhunk://#diff-bc3a70ba28e4b7962d42d894dd244361fd3657378d42225d1d5da5f91c13009aL511-R539) [[4]](diffhunk://#diff-bc3a70ba28e4b7962d42d894dd244361fd3657378d42225d1d5da5f91c13009aL588-R644)

**Authorization Policy Hardening:**

* The `defaultAuthorizationPolicy.allowedApplications` is explicitly set to the app's client ID for both frontend and API, preventing EasyAuth's default deny-all behavior when this field is unset. [[1]](diffhunk://#diff-bc3a70ba28e4b7962d42d894dd244361fd3657378d42225d1d5da5f91c13009aR549-R554) [[2]](diffhunk://#diff-bc3a70ba28e4b7962d42d894dd244361fd3657378d42225d1d5da5f91c13009aR653-R657)

**Reverse Proxy and Header Handling:**

* The NGINX reverse proxy configuration now forwards the `Authorization` header to the API and history endpoints, enabling EasyAuth to validate tokens sent from the frontend. [[1]](diffhunk://#diff-97f78b66605d09c8f6dcbfdca6a9dc20fd63c8fad3e16307d8609c6ac53d82e5R19) [[2]](diffhunk://#diff-97f78b66605d09c8f6dcbfdca6a9dc20fd63c8fad3e16307d8609c6ac53d82e5R39)
* The frontend API client (`api.ts`) now only sends the AAD access token in the `Authorization` header (no longer in `X-ZUMO-AUTH`), avoiding token validation errors due to header misuse.

**Backend Token Extraction:**

* The backend authentication utility (`auth_utils.py`) now supports extracting the Bearer token from the `Authorization` header if not present in EasyAuth headers, improving compatibility with cross-origin and OBO flows.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.