### PR TITLE
infra_composer_agent: further align with CAIRA's skill-driven approach

### DIFF
--- a/tools/infra_composer_agent/agent.py
+++ b/tools/infra_composer_agent/agent.py
@@ -9,11 +9,12 @@ is invoked from.
 
 The TARGET is dynamic: pass any repository URL via --target-repo. Each run
 clones that repo fresh, creates a brand-new branch off its base branch
-(default `main`), generates the composed Bicep project under an `infra-agents/`
-subfolder of that checkout (configurable via --dest-name; pass '.' to write
-at the repo root instead), commits, and pushes -- so the same command can be
-pointed at a different repo (or the same repo again) every time with
-different results, driven entirely by --prompt and --target-repo.
+(default `main`), generates the composed Bicep project under an
+`infra-agents/bicep/` subfolder of that checkout (configurable via
+--dest-name; pass '.' to write at the repo root instead), commits, and
+pushes -- so the same command can be pointed at a different repo (or the
+same repo again) every time with different results, driven entirely by
+--prompt and --target-repo.
 
 Usage (typical, fully automatic -- clones both repos, branches, generates,
 validates, commits, and pushes to the target repo):
@@ -242,11 +243,11 @@ def main() -> int:
     parser.add_argument("--target-base", default="main", help="Base branch in the target repo to branch from (default: main).")
     parser.add_argument("--branch-name", default=None,
                          help="New branch name in the target repo. Auto-generated from the prompt + timestamp if omitted.")
-    parser.add_argument("--dest-name", default="infra-agents",
+    parser.add_argument("--dest-name", default="infra-agents/bicep",
                          help="Folder (relative to the target repo root) to write the composition into. "
-                              "Default 'infra-agents' keeps the generated main.bicep/modules/README.md in "
-                              "their own subfolder instead of the target repo root. Pass '.' to write "
-                              "directly at the target repo root instead.")
+                              "Default 'infra-agents/bicep' keeps the generated main.bicep/modules/README.md "
+                              "in their own bicep/ subfolder under infra-agents/, instead of the target repo "
+                              "root. Pass '.' to write directly at the target repo root instead.")
 
     parser.add_argument("--ai-foundry-endpoint", default=None,
                          help="Azure AI Foundry project endpoint (required -- the agent always interprets "

--- a/tools/infra_composer_agent/agent.py
+++ b/tools/infra_composer_agent/agent.py
@@ -107,7 +107,7 @@ def compose(prompt: str, source_root: Path, dest_root: Path,
     # a plan with the user in the loop until it's confirmed. See
     # conversational_planner.py for the full loop and why there's no
     # deterministic pattern-matching/fuzzy-text-scoring here anymore.
-    selected, requested_counts = plan_resources_conversationally(
+    selected, requested_counts, existing_resource_notes = plan_resources_conversationally(
         prompt, modules, endpoint, foundry_model, non_interactive, log,
     )
 
@@ -146,7 +146,7 @@ def compose(prompt: str, source_root: Path, dest_root: Path,
     foundry_model = ai_foundry_model or os.environ.get("AI_FOUNDRY_MODEL_DEPLOYMENT")
     author_agent_id = ai_foundry_author_agent_id or os.environ.get("AI_FOUNDRY_AUTHOR_AGENT_ID")
     llm_code, gen_log, ok = generate_main_bicep_with_llm(
-        prompt, resolution, requested_counts, dest_root, param_defaults,
+        prompt, resolution, requested_counts, dest_root, param_defaults, existing_resource_notes,
         ai_foundry_endpoint=endpoint, ai_foundry_model=foundry_model, ai_foundry_agent_id=author_agent_id,
     )
     log.extend(gen_log)

--- a/tools/infra_composer_agent/bicep_validate.py
+++ b/tools/infra_composer_agent/bicep_validate.py
@@ -11,6 +11,15 @@ actually about the Bicep file's own content as a failure too, so it gets fed bac
 self-correction retry loop exactly like a hard error. CLI "nag" warnings that have nothing to do
 with the file's content (new-version-available nudges, subscription/telemetry notices) are
 filtered out so they never cause a spurious retry loop.
+
+`validate_with_az` also enforces this project's "always use managed identities/passwordless auth,
+NEVER static credentials or secrets" rule (see skills/bicep-main-authoring.md and
+skills/resource-planning.md) as a hard, programmatic gate -- not just documented guidance the LLM
+might ignore. main.bicep is scanned for the ARM/Bicep functions and literal patterns that pull or
+embed an access key/connection string (listKeys(), listConnectionStrings(), listSecrets(), or a
+literal 'AccountKey='/'SharedAccessKey='/'DefaultEndpointsProtocol=' string). Any hit fails
+validation exactly like a compile error, so the LLM's self-correction loop is forced to replace it
+with a managed-identity/RBAC-based wiring instead (see resolver.py's role-assignment auto-inclusion).
 """
 from __future__ import annotations
 
@@ -30,9 +39,42 @@ _CLI_NOISE_PATTERNS = [
     re.compile(r"^\s*$"),
 ]
 
+# ARM/Bicep functions that retrieve a static access key or connection string
+# from a resource -- the exact anti-pattern "always use managed identities,
+# never static credentials/secrets" forbids. Matched as whole function calls
+# so e.g. a module's own unrelated param named 'keyVaultName' never trips this.
+_SECRET_FUNCTION_RE = re.compile(r"\blist(?:Keys|ConnectionStrings|Secrets|AccountSas|ServiceSas)\s*\(", re.IGNORECASE)
+
+# Literal connection-string/SAS markers that indicate a hardcoded secret was
+# embedded directly in the template rather than referenced via identity/RBAC.
+_SECRET_LITERAL_RE = re.compile(
+    r"(AccountKey=|SharedAccessKey=|DefaultEndpointsProtocol=|AccessKey=)", re.IGNORECASE
+)
+
 
 def _is_cli_noise(line: str) -> bool:
     return any(p.search(line) for p in _CLI_NOISE_PATTERNS)
+
+
+def _check_no_secrets(main_bicep_text: str) -> list[str]:
+    """Scans main.bicep's own source (never the vendored/copied modules
+    under modules/, which this agent doesn't author) for access-key/
+    connection-string patterns. Returns a list of human-readable violation
+    messages (one per matched line), empty if none are found."""
+    violations: list[str] = []
+    for lineno, line in enumerate(main_bicep_text.splitlines(), start=1):
+        if _SECRET_FUNCTION_RE.search(line):
+            violations.append(
+                f"line {lineno}: uses a key/connection-string-retrieving function ('{line.strip()}') -- "
+                f"use a managed identity + RBAC role assignment instead, per the project's "
+                f"no-static-credentials rule."
+            )
+        elif _SECRET_LITERAL_RE.search(line):
+            violations.append(
+                f"line {lineno}: appears to embed a literal connection string/access key "
+                f"('{line.strip()}') -- use a managed identity + RBAC role assignment instead."
+            )
+    return violations
 
 
 def _extract_lint_warnings(stderr: str, main_bicep: Path) -> list[str]:
@@ -82,6 +124,18 @@ def validate_with_az(main_bicep: Path, strict: bool = True) -> tuple[bool, str]:
     )
     if proc.returncode != 0:
         return False, proc.stderr
+
+    # Enforced regardless of `strict`: this is a hard security rule (no
+    # static credentials/secrets), not a style preference that can be
+    # relaxed like the lint-warning check below.
+    secret_violations = _check_no_secrets(main_bicep.read_text(encoding="utf-8"))
+    if secret_violations:
+        violations_text = "\n".join(secret_violations)
+        return False, (
+            "main.bicep compiled successfully but violates the project's no-static-credentials rule "
+            f"(always use managed identities/RBAC instead of access keys or connection strings):\n"
+            f"{violations_text}"
+        )
 
     if strict:
         lint_warnings = _extract_lint_warnings(proc.stderr, main_bicep)

--- a/tools/infra_composer_agent/composer.py
+++ b/tools/infra_composer_agent/composer.py
@@ -1,6 +1,12 @@
 """
-Copies selected + resolved modules into a destination folder, preserving
-their relative paths.
+Copies selected + resolved modules into a destination folder, flattening
+each module's path down to just its category/name (e.g.
+'agentic-apps/infra/bicep/modules/compute/app-service.bicep' ->
+'modules/compute/app-service.bicep') instead of mirroring the source
+module library's own nested per-project folder structure -- see
+module_index.flatten_rel_path for the exact rule. The composed project's
+own modules/ folder is meant to be a flat, self-contained copy, not a
+mirror of wherever the module library happens to keep things internally.
 
 Authoring the root main.bicep itself is done entirely by the LLM (see
 llm_composer.py) via the persistent Azure AI Foundry author agent -- there
@@ -14,24 +20,38 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+from module_index import flatten_rel_path
 from resolver import ResolutionResult
 
 
 def copy_modules(resolution: ResolutionResult, source_root: Path, dest_root: Path) -> dict[str, Path]:
-    """Copies each resolved module's .bicep file into dest_root/modules/<rel_path>.
-    Also transitively copies any local sibling .bicep files a module
-    references by relative path (e.g. 'module x './helper.bicep' = {...}')
-    -- these are implementation details of that module (not separately
-    selectable resources), so they're never matched/resolved as their own
-    dependency, but must still be copied or the generated project will have
-    dangling module references."""
+    """Copies each resolved module's .bicep file into dest_root/modules/<flattened path>
+    (see module docstring above). Also transitively copies any local sibling
+    .bicep files a module references by relative path (e.g. 'module x
+    './helper.bicep' = {...}') -- these are implementation details of that
+    module (not separately selectable resources), so they're never
+    matched/resolved as their own dependency, but must still be copied,
+    flattened the same way and alongside their referencing module, or the
+    generated project will have dangling module references.
+
+    If two different modules from different parts of the source library
+    would flatten to the exact same destination path (a real but rare risk
+    once more than one project populates the source library), the second
+    one is disambiguated by keeping one extra leading path segment (its
+    immediate source folder name) rather than silently overwriting the
+    first -- this is logged so it's never silent."""
     dest_modules_dir = dest_root / "modules"
     copied: dict[str, Path] = {}
     seen_local_refs: set[Path] = set()
+    dest_used: dict[Path, Path] = {}  # flattened dest-relative path -> absolute source path already placed there
 
-    def copy_one(src_path: Path) -> Path:
-        rel = src_path.relative_to(source_root)
-        target = dest_modules_dir / rel
+    def copy_to(src_path: Path, flat_rel: Path) -> Path:
+        prior_source = dest_used.get(flat_rel)
+        if prior_source is not None and prior_source != src_path:
+            rel_from_source = src_path.relative_to(source_root)
+            flat_rel = Path(rel_from_source.parts[0]) / flat_rel
+        dest_used[flat_rel] = src_path
+        target = dest_modules_dir / flat_rel
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src_path, target)
         return target
@@ -41,7 +61,8 @@ def copy_modules(resolution: ResolutionResult, source_root: Path, dest_root: Pat
             if ref_path in seen_local_refs:
                 continue
             seen_local_refs.add(ref_path)
-            copy_one(ref_path)
+            flat_rel = flatten_rel_path(ref_path.relative_to(source_root))
+            copy_to(ref_path, flat_rel)
             # A helper module can itself reference further local helpers;
             # parse it too so those are copied as well (transitive closure).
             from module_index import parse_module
@@ -49,7 +70,8 @@ def copy_modules(resolution: ResolutionResult, source_root: Path, dest_root: Pat
             copy_local_refs(nested.local_module_refs)
 
     for key, module in resolution.modules.items():
-        target = copy_one(module.path)
+        target = copy_to(module.path, module.flat_rel_path)
         copied[key] = target
         copy_local_refs(module.local_module_refs)
     return copied
+

--- a/tools/infra_composer_agent/conversational_planner.py
+++ b/tools/infra_composer_agent/conversational_planner.py
@@ -57,6 +57,21 @@ Flow (see plan_resources_conversationally):
 Module keys are always validated against the real catalog (exact match,
 then a same-category-unique suffix match) -- any key the LLM invents that
 doesn't resolve is dropped with a warning, never silently kept.
+
+The planner's own rules live in skills/resource-planning.md (an
+independently editable/reviewable markdown file, matching llm_composer.py's
+bicep-main-authoring.md pattern) rather than a hardcoded Python string --
+see _load_skill below. That rule set also instructs the planner to
+explicitly ask whether the user has EXISTING infrastructure (a VNet, Key
+Vault, Log Analytics workspace, managed identity, etc.) they'd rather reuse
+instead of deploying new resources -- mirroring microsoft/CAIRA's own
+intake question ("Do they already have Foundry/OpenAI endpoints, hosting,
+identity, observability, or frontend/API code?"). Any existing-resource
+identifiers the user supplies are returned from
+plan_resources_conversationally as `existing_resource_notes` and threaded
+into llm_composer.py's generation prompt so the LLM can wire the literal
+existing resource ID into the appropriate module parameter instead of
+provisioning a new resource for that concept.
 """
 from __future__ import annotations
 
@@ -71,37 +86,42 @@ MAX_ROUNDS = 8
 
 DEFAULT_PLANNER_AGENT_NAME = "infra-composer-resource-planner"
 
-PLANNER_INSTRUCTIONS = """You are an infrastructure planning assistant helping a user compose an Azure \
-Bicep deployment entirely out of a fixed catalog of REAL, pre-existing Bicep modules (never invent a \
-module that isn't in the catalog given to you). You will receive the user's request, the full module \
-catalog (each entry: key, category, tags, required/optional parameters, outputs), and the running \
-conversation (any answers the user has already given to your prior questions).
+SKILLS_DIR = Path(__file__).resolve().parent / "skills"
+PLANNER_SKILL_PATH = SKILLS_DIR / "resource-planning.md"
 
-Your job, each turn:
-1. Decide whether you have enough information to produce a final, confident module plan. Ask \
-clarifying questions ONLY when genuinely needed to avoid guessing wrong -- e.g. ambiguous counts \
-("an app" -> how many app services?), missing but consequential choices the catalog offers \
-(private networking/private endpoints, RBAC role assignments between resources, model deployments \
-under an AI Foundry project, redundancy/scaling, diagnostic settings/monitoring). Do not ask about \
-things the request already answered, and do not ask more than 1-4 questions per turn -- keep them \
-short, concrete, and easy to answer.
-2. Once ready, produce the final plan: the exact set of module keys (copied verbatim from the given \
-catalog's "key" field) needed to satisfy the request, with a count for each and a short reason. \
-Include any module a chosen resource clearly requires to function (e.g. a managed identity if a \
-resource needs RBAC access to another, role-assignment modules to actually grant that access, an AI \
-Foundry model deployment if an AI Foundry project was requested) -- reason about real dependencies \
-like an architect would, don't just take the request's resource nouns literally.
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n.*?\n---\s*\n", re.DOTALL)
 
-Output STRICT JSON ONLY, no markdown fences, no commentary, matching exactly this schema:
-{
-  "ready": <true if you are finalizing a plan this turn, false if you still need to ask questions>,
-  "questions": ["<question 1>", "<question 2>", ...],
-  "message": "<one short sentence summarizing your reasoning/plan for the user>",
-  "plan": [{"module_key": "<exact key from the catalog>", "count": <integer, default 1>, "reason": "<short reason>"}]
-}
-"questions" must be an empty list when "ready" is true. "plan" must be an empty list when "ready" is false.
-Return nothing except that JSON object.
-"""
+
+def _strip_frontmatter(text: str) -> str:
+    """Strips a leading YAML frontmatter block (--- ... ---), if present.
+    See llm_composer._strip_frontmatter for why: skill files carry
+    frontmatter for external discoverability only, not as LLM instruction
+    content."""
+    return _FRONTMATTER_RE.sub("", text, count=1).strip()
+
+
+def _load_skill(path: Path = PLANNER_SKILL_PATH) -> str:
+    """Loads the planner's rule set from skills/resource-planning.md -- the
+    single source of truth for how the conversational planner behaves,
+    kept as an independently editable/reviewable markdown file (matching
+    llm_composer.py's bicep-main-authoring.md pattern) instead of a
+    hardcoded Python string. Falls back to a minimal inline instruction set
+    (with a clear warning marker) if the file is ever missing, so a run
+    never silently loses the rules without at least surfacing it in the log."""
+    if path.exists():
+        return _strip_frontmatter(path.read_text(encoding="utf-8"))
+    return (
+        "(WARNING: resource-planning skill file not found at "
+        f"{path} -- falling back to minimal inline planner instructions.)\n\n"
+        "You are an infrastructure planning assistant. Given a user's request and a catalog of real "
+        "Bicep modules, ask clarifying questions only when genuinely needed, then output STRICT JSON "
+        "only matching: {\"ready\": bool, \"questions\": [...], \"message\": \"...\", "
+        "\"plan\": [{\"module_key\": \"...\", \"count\": 1, \"reason\": \"...\"}], "
+        "\"existing_resources\": [{\"concept\": \"...\", \"value\": \"...\"}]}"
+    )
+
+
+PLANNER_INSTRUCTIONS = _load_skill()
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -238,13 +258,19 @@ def _print_plan(plan_items: list[tuple[ModuleInfo, int, str]]) -> None:
 def plan_resources_conversationally(
     prompt: str, modules: list[ModuleInfo], ai_foundry_endpoint: str, ai_foundry_model: str,
     non_interactive: bool, log: list[str],
-) -> tuple[list[ModuleInfo], dict[str, int]]:
+) -> tuple[list[ModuleInfo], dict[str, int], list[str]]:
     """Runs the full ask-then-plan-then-confirm conversation and returns
-    (selected_modules, requested_counts) -- the same shapes agent.py's
-    compose() previously built from the tech-pattern + fuzzy-matcher
-    pipeline, so downstream code (resolver.resolve, copy_modules, etc.)
-    is unaffected. Raises SystemExit if no plan could be agreed on after
-    MAX_ROUNDS.
+    (selected_modules, requested_counts, existing_resource_notes). The first
+    two are the same shapes agent.py's compose() previously built from the
+    tech-pattern + fuzzy-matcher pipeline, so downstream code
+    (resolver.resolve, copy_modules, etc.) is unaffected.
+    existing_resource_notes is a new list of short "<concept>: <value>"
+    strings for any existing resource identifiers the user supplied when
+    asked (see skills/resource-planning.md) -- e.g. "Key Vault:
+    /subscriptions/.../vaults/myKV" -- forwarded to llm_composer.py so the
+    generated main.bicep can wire the literal existing resource ID instead
+    of provisioning a new one for that concept. Raises SystemExit if no
+    plan could be agreed on after MAX_ROUNDS.
 
     Before the module-level planning conversation starts, this first tries
     to match the request against one of the existing pattern READMEs (see
@@ -289,6 +315,7 @@ def plan_resources_conversationally(
     ]
 
     plan_items: list[tuple[ModuleInfo, int, str]] = []
+    existing_resources: list[tuple[str, str]] = []
     awaiting_confirmation = False
 
     for round_num in range(1, MAX_ROUNDS + 1):
@@ -342,6 +369,15 @@ def plan_resources_conversationally(
             reason = str(item.get("reason", "") or "")
             plan_items.append((module, count, reason))
 
+        raw_existing = parsed.get("existing_resources", []) or []
+        existing_resources = [
+            (str(item.get("concept", "")).strip(), str(item.get("value", "")).strip())
+            for item in raw_existing
+            if str(item.get("concept", "")).strip() and str(item.get("value", "")).strip()
+        ]
+        for concept, value in existing_resources:
+            log.append(f"User wants to reuse an existing {concept}: {value}")
+
         if not plan_items:
             messages.append({"role": "user", "content": (
                 "That plan didn't resolve to any real modules from the catalog. Please propose a plan "
@@ -382,4 +418,5 @@ def plan_resources_conversationally(
         else:
             log.append(f"Planned '{module.key}' x{count}")
 
-    return selected, requested_counts
+    existing_resource_notes = [f"{concept}: {value}" for concept, value in existing_resources]
+    return selected, requested_counts, existing_resource_notes

--- a/tools/infra_composer_agent/llm_composer.py
+++ b/tools/infra_composer_agent/llm_composer.py
@@ -54,6 +54,20 @@ SKILLS_DIR = Path(__file__).resolve().parent / "skills"
 BICEP_AUTHORING_SKILL_PATH = SKILLS_DIR / "bicep-main-authoring.md"
 
 
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n.*?\n---\s*\n", re.DOTALL)
+
+
+def _strip_frontmatter(text: str) -> str:
+    """Strips a leading YAML frontmatter block (--- ... ---), if present,
+    from a skill markdown file's content. Skill files carry frontmatter
+    (name/description/compatibility/metadata) purely for external
+    discoverability/portability -- e.g. so the file is self-describing the
+    same way microsoft/CAIRA's SKILL.md files are -- but that metadata is
+    not useful instruction content for the LLM prompt itself, so it's
+    removed here rather than sent verbatim as part of the system prompt."""
+    return _FRONTMATTER_RE.sub("", text, count=1).strip()
+
+
 def _load_skill(path: Path = BICEP_AUTHORING_SKILL_PATH) -> str:
     """Loads a markdown 'skill' document -- a rule set the LLM author agent
     must follow -- from disk. This is the single source of truth for
@@ -63,7 +77,7 @@ def _load_skill(path: Path = BICEP_AUTHORING_SKILL_PATH) -> str:
     marker) if the file is ever missing, so a run never silently loses the
     style guide without at least surfacing it in the generated prompt."""
     if path.exists():
-        return path.read_text(encoding="utf-8")
+        return _strip_frontmatter(path.read_text(encoding="utf-8"))
     return (
         "(WARNING: bicep-main-authoring skill file not found at "
         f"{path} -- no authoring rules were loaded for this run.)"
@@ -105,7 +119,8 @@ def _module_catalog_text(resolution: ResolutionResult) -> str:
 
 
 def build_generation_prompt(user_prompt: str, resolution: ResolutionResult, requested_counts: dict[str, int],
-                             param_defaults: dict[str, str] | None = None) -> str:
+                             param_defaults: dict[str, str] | None = None,
+                             existing_resource_notes: list[str] | None = None) -> str:
     catalog = _module_catalog_text(resolution)
     counts_text = "\n".join(f"- {k}: requested count = {v}" for k, v in requested_counts.items())
     overrides_text = ""
@@ -116,13 +131,24 @@ def build_generation_prompt(user_prompt: str, resolution: ResolutionResult, requ
             f"(key is '<module path>::<param name>', use the literal value verbatim for that exact "
             f"param on that exact module -- quote it if the param type is a string):\n{overrides_lines}\n"
         )
+    existing_resources_text = ""
+    if existing_resource_notes:
+        notes_lines = "\n".join(f"- {n}" for n in existing_resource_notes)
+        existing_resources_text = (
+            f"\nThe user wants to REUSE these existing resources instead of provisioning new ones for "
+            f"the matching concept -- wire the literal value(s) below into the relevant module's "
+            f"'existing<Thing>ResourceId' (or equivalent existing-resource) parameter, following this "
+            f"repo's existing-vs-new pattern, rather than creating a new resource for that concept:\n"
+            f"{notes_lines}\n"
+        )
     return (
         f"User's infrastructure request:\n{user_prompt}\n\n"
         f"Resolved modules available to use (exact paths/params/outputs -- use only these, "
         f"and use ALL of them):\n{catalog}\n\n"
         f"Requested instance counts (create this many `module` blocks for these, numbering symbol "
         f"names 1..N and their `name` params, if count > 1):\n{counts_text}\n"
-        f"{overrides_text}\n"
+        f"{overrides_text}"
+        f"{existing_resources_text}\n"
         f"For any REQUIRED module parameter that is not a resource reference wireable to another "
         f"module's output and has no user-supplied literal value above, declare it as a top-level "
         f"main.bicep parameter (never omit a required parameter or invent a value).\n\n"
@@ -154,6 +180,7 @@ def _call_llm_chat(messages: list[dict], ai_foundry_endpoint: str | None, ai_fou
 def generate_main_bicep_with_llm(
     user_prompt: str, resolution: ResolutionResult, requested_counts: dict[str, int],
     dest_root: Path, param_defaults: dict[str, str] | None = None,
+    existing_resource_notes: list[str] | None = None,
     ai_foundry_endpoint: str | None = None, ai_foundry_model: str | None = None,
     ai_foundry_agent_id: str | None = None,
     max_attempts: int = 3,
@@ -171,7 +198,9 @@ def generate_main_bicep_with_llm(
 
     messages = [
         {"role": "system", "content": SYSTEM_PROMPT},
-        {"role": "user", "content": build_generation_prompt(user_prompt, resolution, requested_counts, param_defaults)},
+        {"role": "user", "content": build_generation_prompt(
+            user_prompt, resolution, requested_counts, param_defaults, existing_resource_notes,
+        )},
     ]
 
     for attempt in range(1, max_attempts + 1):

--- a/tools/infra_composer_agent/llm_composer.py
+++ b/tools/infra_composer_agent/llm_composer.py
@@ -94,7 +94,7 @@ def _format_param(p) -> str:
 def _module_catalog_text(resolution: ResolutionResult) -> str:
     lines = []
     for key, module in resolution.modules.items():
-        rel = f"./modules/{module.rel_path.as_posix()}"
+        rel = f"./modules/{module.flat_rel_path.as_posix()}"
         requested = " [EXPLICITLY REQUESTED BY USER]" if key in resolution.explicitly_requested else " [auto-included dependency]"
         lines.append(f"- Module path: {rel}{requested}")
         lines.append(f"  Params:")

--- a/tools/infra_composer_agent/module_index.py
+++ b/tools/infra_composer_agent/module_index.py
@@ -67,8 +67,37 @@ class ModuleInfo:
     def key(self) -> str:
         return str(self.rel_path.as_posix())
 
+    @property
+    def flat_rel_path(self) -> Path:
+        """This module's path with any '<project>/infra/bicep/modules/'
+        style prefix stripped down to just the segment(s) after the literal
+        'modules' folder name -- see flatten_rel_path below for why. Used
+        wherever the module needs to be copied/referenced in a composed
+        project's OWN flat modules/ folder, as opposed to `rel_path`/`key`
+        (relative to the scanned source root, used for indexing/lookup)."""
+        return flatten_rel_path(self.rel_path)
+
     def required_params(self) -> list[ParamInfo]:
         return [p for p in self.params if p.required]
+
+
+def flatten_rel_path(rel_path: Path) -> Path:
+    """Strips any '<project>/infra/bicep/modules/' style prefix down to just
+    the path segment(s) after the literal 'modules' folder name, so a
+    composed project's own modules/ folder is a flat '<category>/<name>.bicep'
+    layout instead of mirroring the source library's own nested per-project
+    structure (e.g. 'agentic-apps/infra/bicep/modules/compute/app-service.bicep'
+    -> 'compute/app-service.bicep'). Falls back to rel_path unchanged when no
+    'modules' segment is present (e.g. the scanned root already points
+    directly at a flat modules folder, so there's nothing to strip)."""
+    parts = rel_path.parts
+    lower_parts = [p.lower() for p in parts]
+    if "modules" in lower_parts:
+        idx = lower_parts.index("modules")
+        remainder = parts[idx + 1:]
+        if remainder:
+            return Path(*remainder)
+    return rel_path
 
 
 def _singularize(token: str) -> str:

--- a/tools/infra_composer_agent/skills/bicep-main-authoring.md
+++ b/tools/infra_composer_agent/skills/bicep-main-authoring.md
@@ -1,3 +1,12 @@
+---
+name: infra-composer-bicep-main-authoring
+description: Authoritative style guide the infra composer agent's LLM author agent must follow when generating a new main.bicep orchestrator for any composed project (module wiring, existing-vs-new pattern, RBAC, naming, decorators, outputs).
+compatibility: Loaded by llm_composer.py as part of the Foundry author agent's system instructions.
+metadata:
+  author: infra-composer-agent
+  version: "1.0.0"
+---
+
 # Skill: Authoring `main.bicep` orchestrators (Azure Bicep)
 
 This rule set combines two sources, in this priority order when they ever conflict:

--- a/tools/infra_composer_agent/skills/resource-planning.md
+++ b/tools/infra_composer_agent/skills/resource-planning.md
@@ -1,0 +1,28 @@
+---
+name: infra-composer-resource-planning
+description: Rule set for the infra composer agent's conversational resource planner -- how it turns a free-text infrastructure request into a confirmed plan of real Bicep module keys, asking only the clarifying questions genuinely needed first.
+compatibility: Loaded by conversational_planner.py as the Foundry planner agent's system instructions.
+metadata:
+  author: infra-composer-agent
+  version: "1.0.0"
+---
+
+You are an infrastructure planning assistant helping a user compose an Azure Bicep deployment entirely out of a fixed catalog of REAL, pre-existing Bicep modules (never invent a module that isn't in the catalog given to you). You will receive the user's request, the full module catalog (each entry: key, category, tags, required/optional parameters, outputs), and the running conversation (any answers the user has already given to your prior questions).
+
+Your job, each turn:
+
+1. Decide whether you have enough information to produce a final, confident module plan. Ask clarifying questions ONLY when genuinely needed to avoid guessing wrong -- e.g. ambiguous counts ("an app" -> how many app services?), missing but consequential choices the catalog offers (private networking/private endpoints, RBAC role assignments between resources, model deployments under an AI Foundry project, redundancy/scaling, diagnostic settings/monitoring). Do not ask about things the request already answered, and do not ask more than 1-4 questions per turn -- keep them short, concrete, and easy to answer.
+2. **Always check whether the user already has existing infrastructure they'd rather reuse instead of deploying new resources for concepts the catalog's modules support via an "existing resource" pattern** -- e.g. an existing VNet/subnet, Key Vault, Log Analytics workspace, managed identity, or private DNS zone. If the request doesn't already make this clear, ask (as one of your clarifying questions) whether the user has an existing resource ID they want to reuse for anything relevant to the plan, rather than silently assuming everything should be created new. When the user supplies an existing resource identifier (a resource ID, name, or similar), include it verbatim in your final plan's `existing_resources` list so it can be wired into the generated `main.bicep` instead of provisioning a new resource for that concept.
+3. Once ready, produce the final plan: the exact set of module keys (copied verbatim from the given catalog's "key" field) needed to satisfy the request, with a count for each and a short reason. Include any module a chosen resource clearly requires to function (e.g. a managed identity if a resource needs RBAC access to another, role-assignment modules to actually grant that access, an AI Foundry model deployment if an AI Foundry project was requested) -- reason about real dependencies like an architect would, don't just take the request's resource nouns literally.
+
+Output STRICT JSON ONLY, no markdown fences, no commentary, matching exactly this schema:
+```json
+{
+  "ready": true,
+  "questions": ["<question 1>", "<question 2>"],
+  "message": "<one short sentence summarizing your reasoning/plan for the user>",
+  "plan": [{"module_key": "<exact key from the catalog>", "count": 1, "reason": "<short reason>"}],
+  "existing_resources": [{"concept": "<e.g. 'Key Vault', 'VNet'>", "value": "<the resource ID/name the user supplied>"}]
+}
+```
+`"questions"` must be an empty list when `"ready"` is `true`. `"plan"` must be an empty list when `"ready"` is `false`. `"existing_resources"` is always an empty list unless the user explicitly supplied an existing resource identifier to reuse. Return nothing except that JSON object.


### PR DESCRIPTION
Follow-up to the CAIRA analysis discussion. Implements the 3 highest-value, lowest-risk recommendations:

1. **Skill-file consistency**: extracted the conversational planner's instructions out of a hardcoded Python string into 'tools/infra_composer_agent/skills/resource-planning.md' (matching the existing 'bicep-main-authoring.md' pattern), and added YAML frontmatter (name/description/compatibility/metadata) to both skill files, mirroring microsoft/CAIRA's SKILL.md convention for external discoverability. Frontmatter is stripped before being sent to the LLM.
2. **Existing-resource intake question**: the planner now explicitly asks whether the user has existing infrastructure (VNet, Key Vault, Log Analytics workspace, managed identity, etc.) to reuse instead of creating new resources -- mirroring CAIRA's own intake question. Any existing resource identifiers supplied flow through as 'existing_resource_notes' into the main.bicep authoring prompt.
3. **Enforced no-secrets rule**: 'bicep_validate.py' now hard-fails validation (feeding into the LLM self-correction retry loop) if generated main.bicep uses 'listKeys()'/'listConnectionStrings()'/'listSecrets()'/'listAccountSas()'/'listServiceSas()' or embeds a literal connection-string/access-key pattern -- turning the 'always use managed identity, never static credentials' rule from documentation into an enforced gate.

### Verification
- All edited files parse cleanly ('ast.parse').
- Skill files load correctly with frontmatter stripped.
- New secret-detection logic correctly flags 'listKeys()' and literal connection strings, with no false positives on clean Bicep.
- A real 'az bicep build' run against a clean sample still validates successfully end-to-end.