### PR TITLE
fix: update sample questions for Retail scenario in Deployment Guide

### DIFF
--- a/documents/DeploymentGuide.md
+++ b/documents/DeploymentGuide.md
@@ -401,7 +401,7 @@ Once you've opened the project in [Codespaces](#github-codespaces), [Dev Contain
 
     | Scenario | Sample Questions |
     |----------|-----------------|
-    | **Retail (Default)** | "Show the top 5 products by total quantity sold last month?"<br /> "Show total revenue by year for last 5 years" <br /> "Show top 10 products by Revenue in the last year" |
+    | **Retail (Default)** | "Show the top 5 products by total quantity sold"<br /> "Show total revenue by year for last 5 years" <br /> "Show top 10 products by Revenue" |
     | **Insurance** | "I'm meeting Ida Abolina. Can you summarize her customer information and tell me the number of claims, payments, and communications she's had?" <br /> "Can you provide details of her communications?" <br /> "Based on Ida's policy data has she ever missed a payment?" |
 
 11. Once the build has completed successfully, go to the deployed resource group, find the App Service, and get the app URL from `Default domain`.

--- a/documents/DeploymentGuide.md
+++ b/documents/DeploymentGuide.md
@@ -401,7 +401,7 @@ Once you've opened the project in [Codespaces](#github-codespaces), [Dev Contain
 
     | Scenario | Sample Questions |
     |----------|-----------------|
-    | **Retail (Default)** | "Show the top 5 products by total quantity sold"<br /> "Show total revenue by year for last 5 years" <br /> "Show top 10 products by Revenue" |
+    | **Retail (Default)** | "Show the top 5 products by total quantity sold"<br /> "Show total revenue by year for last 5 years" <br /> "Show top 10 products by revenue" |
     | **Insurance** | "I'm meeting Ida Abolina. Can you summarize her customer information and tell me the number of claims, payments, and communications she's had?" <br /> "Can you provide details of her communications?" <br /> "Based on Ida's policy data has she ever missed a payment?" |
 
 11. Once the build has completed successfully, go to the deployed resource group, find the App Service, and get the app URL from `Default domain`.


### PR DESCRIPTION
## Purpose
This pull request makes a minor update to the sample questions listed for the Retail scenario in `documents/DeploymentGuide.md`. The changes simplify the example queries by removing specific time constraints.

* Documentation update:
  * Simplified Retail scenario sample questions by removing references to "last month" and "last year" in the example queries in `documents/DeploymentGuide.md`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

